### PR TITLE
Fix relay loading order

### DIFF
--- a/contents/relayer.ts
+++ b/contents/relayer.ts
@@ -6,7 +6,8 @@ import { relay } from "@plasmohq/messaging/relay"
 import { WaalletMessage } from "~packages/provider/waallet/message"
 
 export const config: PlasmoCSConfig = {
-  matches: ["<all_urls>"]
+  matches: ["<all_urls>"],
+  run_at: "document_start"
 }
 
 relay(


### PR DESCRIPTION
When using in testing dapp, the relay content script is loaded after main world content script, which causes the first `useBalance` is fired before relay is setup when reloading the page.