### PR TITLE
bug: Normalize the address obtained from the DApp.

### DIFF
--- a/packages/provider/waallet/background/provider.ts
+++ b/packages/provider/waallet/background/provider.ts
@@ -82,13 +82,16 @@ export class WaalletBackgroundProvider {
       // TODO: When `to` is empty, it should estimate gas for contract creation
       return
     }
-    if (tx.from && tx.from !== (await this.account.getAddress())) {
+    if (
+      tx.from &&
+      ethers.getAddress(tx.from) !== (await this.account.getAddress())
+    ) {
       throw new Error("Address `from` doesn't match connected account")
     }
     // TODO: Use account's entry point
     const [entryPointAddress] = await this.bundler.getSupportedEntryPoints()
     const userOpCall = await this.account.createUserOperationCall({
-      to: tx.to,
+      to: ethers.getAddress(tx.to),
       value: tx.value,
       data: tx.data
     })
@@ -136,14 +139,17 @@ export class WaalletBackgroundProvider {
       // TODO: When `to` is empty, it should create contract
       return
     }
-    if (tx.from && tx.from !== (await this.account.getAddress())) {
+    if (
+      tx.from &&
+      ethers.getAddress(tx.from) !== (await this.account.getAddress())
+    ) {
       throw new Error("Address `from` doesn't match connected account")
     }
     // TODO: Use account's entry point
     const [entryPointAddress] = await this.bundler.getSupportedEntryPoints()
     // TODO: Integrate paymaster
     const userOpCall = await this.account.createUserOperationCall({
-      to: tx.to,
+      to: ethers.getAddress(tx.to),
       value: tx.value,
       data: tx.data,
       nonce: tx.nonce

--- a/packages/provider/waallet/background/provider.ts
+++ b/packages/provider/waallet/background/provider.ts
@@ -91,7 +91,7 @@ export class WaalletBackgroundProvider {
     // TODO: Use account's entry point
     const [entryPointAddress] = await this.bundler.getSupportedEntryPoints()
     const userOpCall = await this.account.createUserOperationCall({
-      to: ethers.getAddress(tx.to),
+      to: tx.to,
       value: tx.value,
       data: tx.data
     })
@@ -149,7 +149,7 @@ export class WaalletBackgroundProvider {
     const [entryPointAddress] = await this.bundler.getSupportedEntryPoints()
     // TODO: Integrate paymaster
     const userOpCall = await this.account.createUserOperationCall({
-      to: ethers.getAddress(tx.to),
+      to: tx.to,
       value: tx.value,
       data: tx.data,
       nonce: tx.nonce


### PR DESCRIPTION
# bug: Normalize the address obtained from the DApp.


# doc: Added current results demo and reproduction process markdown

## Issue linked
- Resolves #47

## Issue description
1. For instance, the [Uniswap DApp](https://app.uniswap.org/swap) does not perform address normalization, resulting in persistent "doesn't match" errors.

