### PR TITLE
feat: Opt for a higher estimated gasLimit.

### DIFF
--- a/tabs/userOperationAuthorization.tsx
+++ b/tabs/userOperationAuthorization.tsx
@@ -66,11 +66,25 @@ const UserOperationAuthorization = () => {
     userOp.setPaymasterAndData(
       await o.paymaster.requestPaymasterAndData(userOp)
     )
-    userOp.setGasLimit(
-      await provider.send(WaalletRpcMethod.eth_estimateUserOperationGas, [
-        userOp.data()
-      ])
+    const gasLimit = await provider.send(
+      WaalletRpcMethod.eth_estimateUserOperationGas,
+      [userOp.data()]
     )
+    userOp.setGasLimit({
+      // Opt for a higher estimated gasLimit here to minimize the risk of transaction failure caused by reaching the gas limit.
+      preVerificationGas:
+        gasLimit.preVerificationGas > userOp.preVerificationGas
+          ? gasLimit.preVerificationGas
+          : userOp.preVerificationGas,
+      verificationGasLimit:
+        gasLimit.verificationGasLimit > userOp.verificationGasLimit
+          ? gasLimit.verificationGasLimit
+          : userOp.verificationGasLimit,
+      callGasLimit:
+        gasLimit.callGasLimit > userOp.callGasLimit
+          ? gasLimit.callGasLimit
+          : userOp.callGasLimit
+    })
     setUserOpData(userOp.data())
   }
 


### PR DESCRIPTION
# feat: Opt for a higher estimated gasLimit.

## Issue linked
- Resolves #55

## Descriptions
1. Opt for a higher estimated gasLimit here to minimize the risk of transaction failure caused by reaching the gas limit.
2. To avoid the "AA40 over verificationGasLimit" error during Uniswap transactions due to a low verificationGasLimit.

## Related PR
- [PR #53](https://github.com/pilagod/waallet-extension/pull/53)