### PR TITLE
Separate stringify into standalone function

### DIFF
--- a/app/page/info.tsx
+++ b/app/page/info.tsx
@@ -6,7 +6,7 @@ import { useProviderContext } from "~app/context/provider"
 import { NavbarLayout } from "~app/layout/navbar"
 import { Path } from "~app/path"
 import { useAccount } from "~app/storage"
-import { stringify2 } from "~packages/util/json"
+import { format } from "~packages/util/json"
 import type { HexString } from "~typing"
 
 export function Info() {
@@ -236,7 +236,7 @@ const transactionsCrawler = async (type: transactionType, url: string) => {
 
     const blocks: number[] = [...blocksSet]
 
-    console.log(`hashes: ${stringify2(hashes)}\nblocks: ${stringify2(blocks)}`)
+    console.log(`hashes: ${format(hashes)}\nblocks: ${format(blocks)}`)
 
     return Promise.resolve(hashes)
   } catch (error) {

--- a/app/page/info.tsx
+++ b/app/page/info.tsx
@@ -6,6 +6,7 @@ import { useProviderContext } from "~app/context/provider"
 import { NavbarLayout } from "~app/layout/navbar"
 import { Path } from "~app/path"
 import { useAccount } from "~app/storage"
+import { stringify2 } from "~packages/util/json"
 import type { HexString } from "~typing"
 
 export function Info() {
@@ -235,13 +236,7 @@ const transactionsCrawler = async (type: transactionType, url: string) => {
 
     const blocks: number[] = [...blocksSet]
 
-    console.log(
-      `hashes: ${JSON.stringify(hashes, null, 2)}\nblocks: ${JSON.stringify(
-        blocks,
-        null,
-        2
-      )}`
-    )
+    console.log(`hashes: ${stringify2(hashes)}\nblocks: ${stringify2(blocks)}`)
 
     return Promise.resolve(hashes)
   } catch (error) {

--- a/app/page/webauthn/devtool.tsx
+++ b/app/page/webauthn/devtool.tsx
@@ -3,7 +3,7 @@ import { runtime, type Runtime } from "webextension-polyfill"
 
 import { sendToContentScript } from "@plasmohq/messaging"
 
-import json from "~packages/util/json"
+import { stringify2 } from "~packages/util/json"
 import { objectFromUrlParams } from "~packages/util/url"
 import { createWebAuthn, requestWebAuthn } from "~packages/webAuthn"
 import {
@@ -56,9 +56,7 @@ export function WebAuthnDevTool() {
     }
     setPort(runtimePort)
     runtimePort.onMessage.addListener((message) => {
-      console.log(
-        `[tab][createWebAuthn] runtimePort: ${json.stringify(message, null, 2)}`
-      )
+      console.log(`[tab][createWebAuthn] runtimePort: ${stringify2(message)}`)
     })
     return () => {
       // Disconnect the port
@@ -90,11 +88,7 @@ export function WebAuthnDevTool() {
       body: webAuthnRequest
     } as ContentRequestArguments
     console.log(
-      `[tab][createWebAuthnViaContents] contentReq: ${json.stringify(
-        contentReq,
-        null,
-        2
-      )}`
+      `[tab][createWebAuthnViaContents] contentReq: ${stringify2(contentReq)}`
     )
 
     // When requesting the Content Script to create a WebAuthn, the response is consistently undefined.
@@ -107,9 +101,7 @@ export function WebAuthnDevTool() {
       const cred = await createWebAuthn(webAuthnCreation)
       // Resolve TypeError: Do not know how to serialize a BigInt
       // Refer: https://github.com/GoogleChromeLabs/jsbi/issues/30
-      console.log(
-        `[tab][createWebAuthn] credential: ${json.stringify(cred, null, 2)}`
-      )
+      console.log(`[tab][createWebAuthn] credential: ${stringify2(cred)}`)
       setCredential(cred)
 
       // send to background that create this window
@@ -138,9 +130,7 @@ export function WebAuthnDevTool() {
       )
       // Resolve TypeError: Do not know how to serialize a BigInt
       // Refer: https://github.com/GoogleChromeLabs/jsbi/issues/30
-      console.log(
-        `[tab][requestWebAuthn] signature: ${json.stringify(sig, null, 2)}`
-      )
+      console.log(`[tab][requestWebAuthn] signature: ${stringify2(sig)}`)
       setSignature(sig)
 
       // send to background that create this window
@@ -187,14 +177,14 @@ export function WebAuthnDevTool() {
         <div></div>
       ) : (
         <div>
-          <p>WebAuthn credential: {json.stringify(credential, null, 2)}</p>
+          <p>WebAuthn credential: {stringify2(credential)}</p>
         </div>
       )}
       {signature === undefined ? (
         <div></div>
       ) : (
         <div>
-          <p>WebAuthn signature: {json.stringify(signature, null, 2)}</p>
+          <p>WebAuthn signature: {stringify2(signature)}</p>
         </div>
       )}
     </>

--- a/app/page/webauthn/devtool.tsx
+++ b/app/page/webauthn/devtool.tsx
@@ -3,7 +3,7 @@ import { runtime, type Runtime } from "webextension-polyfill"
 
 import { sendToContentScript } from "@plasmohq/messaging"
 
-import { stringify2 } from "~packages/util/json"
+import { format } from "~packages/util/json"
 import { objectFromUrlParams } from "~packages/util/url"
 import { createWebAuthn, requestWebAuthn } from "~packages/webAuthn"
 import {
@@ -56,7 +56,7 @@ export function WebAuthnDevTool() {
     }
     setPort(runtimePort)
     runtimePort.onMessage.addListener((message) => {
-      console.log(`[tab][createWebAuthn] runtimePort: ${stringify2(message)}`)
+      console.log(`[tab][createWebAuthn] runtimePort: ${format(message)}`)
     })
     return () => {
       // Disconnect the port
@@ -88,7 +88,7 @@ export function WebAuthnDevTool() {
       body: webAuthnRequest
     } as ContentRequestArguments
     console.log(
-      `[tab][createWebAuthnViaContents] contentReq: ${stringify2(contentReq)}`
+      `[tab][createWebAuthnViaContents] contentReq: ${format(contentReq)}`
     )
 
     // When requesting the Content Script to create a WebAuthn, the response is consistently undefined.
@@ -101,7 +101,7 @@ export function WebAuthnDevTool() {
       const cred = await createWebAuthn(webAuthnCreation)
       // Resolve TypeError: Do not know how to serialize a BigInt
       // Refer: https://github.com/GoogleChromeLabs/jsbi/issues/30
-      console.log(`[tab][createWebAuthn] credential: ${stringify2(cred)}`)
+      console.log(`[tab][createWebAuthn] credential: ${format(cred)}`)
       setCredential(cred)
 
       // send to background that create this window
@@ -130,7 +130,7 @@ export function WebAuthnDevTool() {
       )
       // Resolve TypeError: Do not know how to serialize a BigInt
       // Refer: https://github.com/GoogleChromeLabs/jsbi/issues/30
-      console.log(`[tab][requestWebAuthn] signature: ${stringify2(sig)}`)
+      console.log(`[tab][requestWebAuthn] signature: ${format(sig)}`)
       setSignature(sig)
 
       // send to background that create this window
@@ -177,14 +177,14 @@ export function WebAuthnDevTool() {
         <div></div>
       ) : (
         <div>
-          <p>WebAuthn credential: {stringify2(credential)}</p>
+          <p>WebAuthn credential: {format(credential)}</p>
         </div>
       )}
       {signature === undefined ? (
         <div></div>
       ) : (
         <div>
-          <p>WebAuthn signature: {stringify2(signature)}</p>
+          <p>WebAuthn signature: {format(signature)}</p>
         </div>
       )}
     </>

--- a/background/messages/mCreateWindow.ts
+++ b/background/messages/mCreateWindow.ts
@@ -1,6 +1,6 @@
 import { type PlasmoMessaging } from "@plasmohq/messaging"
 
-import json from "~packages/util/json"
+import { stringify2 } from "~packages/util/json"
 import { testWebAuthn } from "~packages/webAuthn/background/webAuthn"
 import type {
   WebAuthnCreation,
@@ -18,9 +18,7 @@ const handler: PlasmoMessaging.MessageHandler<
   RequestBody,
   ResponseBody
 > = async (req, res) => {
-  console.log(
-    `[background][messaging][window] Request: ${JSON.stringify(req, null, 2)}`
-  )
+  console.log(`[background][messaging][window] Request: ${stringify2(req)}`)
 
   const { result } = await testWebAuthn(req.sender.tab.id, {
     webAuthnCreation: req.body.creation,
@@ -38,11 +36,7 @@ const handler: PlasmoMessaging.MessageHandler<
   //   })
 
   console.log(
-    `[background][messaging][window] response: ${json.stringify(
-      await result,
-      null,
-      2
-    )}`
+    `[background][messaging][window] response: ${stringify2(await result)}`
   )
 
   res.send({

--- a/background/messages/mCreateWindow.ts
+++ b/background/messages/mCreateWindow.ts
@@ -1,6 +1,6 @@
 import { type PlasmoMessaging } from "@plasmohq/messaging"
 
-import { stringify2 } from "~packages/util/json"
+import { format } from "~packages/util/json"
 import { testWebAuthn } from "~packages/webAuthn/background/webAuthn"
 import type {
   WebAuthnCreation,
@@ -18,7 +18,7 @@ const handler: PlasmoMessaging.MessageHandler<
   RequestBody,
   ResponseBody
 > = async (req, res) => {
-  console.log(`[background][messaging][window] Request: ${stringify2(req)}`)
+  console.log(`[background][messaging][window] Request: ${format(req)}`)
 
   const { result } = await testWebAuthn(req.sender.tab.id, {
     webAuthnCreation: req.body.creation,
@@ -36,7 +36,7 @@ const handler: PlasmoMessaging.MessageHandler<
   //   })
 
   console.log(
-    `[background][messaging][window] response: ${stringify2(await result)}`
+    `[background][messaging][window] response: ${format(await result)}`
   )
 
   res.send({

--- a/contents/messages.ts
+++ b/contents/messages.ts
@@ -2,7 +2,7 @@ import type { PlasmoCSConfig } from "plasmo"
 
 import { listen } from "@plasmohq/messaging/message"
 
-import { stringify2 } from "~packages/util/json"
+import { format } from "~packages/util/json"
 import { ContentMethod } from "~packages/webAuthn/content/method"
 import {
   contentCreateWebAuthn,
@@ -27,7 +27,7 @@ let credentialId: B64UrlString = ""
 // Non-hook usage reference: https://github.com/PlasmoHQ/plasmo/blob/888b6015c3829872f78428ca0f07640989f6608c/api/messaging/src/hook.ts#L18
 const Messages = () => {
   listen<Record<string, any>, Record<string, any>>(async (req, res) => {
-    console.log(`[contents][messages] req: ${stringify2(req)}`)
+    console.log(`[contents][messages] req: ${format(req)}`)
 
     if (!req.name) {
       console.log(`[contents][messages] status: method not found`)

--- a/contents/messages.ts
+++ b/contents/messages.ts
@@ -2,6 +2,7 @@ import type { PlasmoCSConfig } from "plasmo"
 
 import { listen } from "@plasmohq/messaging/message"
 
+import { stringify2 } from "~packages/util/json"
 import { ContentMethod } from "~packages/webAuthn/content/method"
 import {
   contentCreateWebAuthn,
@@ -26,7 +27,7 @@ let credentialId: B64UrlString = ""
 // Non-hook usage reference: https://github.com/PlasmoHQ/plasmo/blob/888b6015c3829872f78428ca0f07640989f6608c/api/messaging/src/hook.ts#L18
 const Messages = () => {
   listen<Record<string, any>, Record<string, any>>(async (req, res) => {
-    console.log(`[contents][messages] req: ${JSON.stringify(req, null, 2)}`)
+    console.log(`[contents][messages] req: ${stringify2(req)}`)
 
     if (!req.name) {
       console.log(`[contents][messages] status: method not found`)

--- a/packages/account/PasskeyAccount/passkeyOwnerWebAuthn.ts
+++ b/packages/account/PasskeyAccount/passkeyOwnerWebAuthn.ts
@@ -3,7 +3,7 @@ import * as ethers from "ethers"
 import browser from "webextension-polyfill"
 
 import type { PasskeyOwner } from "~packages/account/PasskeyAccount/passkeyOwner"
-import json from "~packages/util/json"
+import { stringify2 } from "~packages/util/json"
 import { requestWebAuthn } from "~packages/webAuthn/background/webAuthn"
 import type { B64UrlString, BytesLike } from "~typing"
 
@@ -48,10 +48,8 @@ export class PasskeyOwnerWebAuthn implements PasskeyOwner {
     const webAuthnAuthentication = await webAuthnAuthenticationPromise
 
     console.log(
-      `[passkeyOwnerWebAuthn] webAuthnAuthentication: ${json.stringify(
-        webAuthnAuthentication,
-        null,
-        2
+      `[passkeyOwnerWebAuthn] webAuthnAuthentication: ${stringify2(
+        webAuthnAuthentication
       )}`
     )
 

--- a/packages/account/PasskeyAccount/passkeyOwnerWebAuthn.ts
+++ b/packages/account/PasskeyAccount/passkeyOwnerWebAuthn.ts
@@ -3,7 +3,7 @@ import * as ethers from "ethers"
 import browser from "webextension-polyfill"
 
 import type { PasskeyOwner } from "~packages/account/PasskeyAccount/passkeyOwner"
-import { stringify2 } from "~packages/util/json"
+import { format } from "~packages/util/json"
 import { requestWebAuthn } from "~packages/webAuthn/background/webAuthn"
 import type { B64UrlString, BytesLike } from "~typing"
 
@@ -48,7 +48,7 @@ export class PasskeyOwnerWebAuthn implements PasskeyOwner {
     const webAuthnAuthentication = await webAuthnAuthenticationPromise
 
     console.log(
-      `[passkeyOwnerWebAuthn] webAuthnAuthentication: ${stringify2(
+      `[passkeyOwnerWebAuthn] webAuthnAuthentication: ${format(
         webAuthnAuthentication
       )}`
     )

--- a/packages/rpc/json/provider.ts
+++ b/packages/rpc/json/provider.ts
@@ -1,6 +1,6 @@
 import fetch from "isomorphic-fetch"
 
-import json, { replacer, stringify2 } from "~packages/util/json"
+import json, { format, replacer } from "~packages/util/json"
 
 export class JsonRpcProvider {
   public constructor(public readonly rpcUrl: string) {}
@@ -37,9 +37,7 @@ export class JsonRpcProvider {
     //     error: { code: -32521, message: "user operation's call reverted: 0x" },
     //     id: 0
     // }
-    console.log(
-      `[JsonRpcProvider][${args.method}][response] ${stringify2(data)}`
-    )
+    console.log(`[JsonRpcProvider][${args.method}][response] ${format(data)}`)
     // TODO: Transform error to error instance
     return data.result as T
   }

--- a/packages/rpc/json/provider.ts
+++ b/packages/rpc/json/provider.ts
@@ -1,6 +1,6 @@
 import fetch from "isomorphic-fetch"
 
-import json, { replacer } from "~packages/util/json"
+import json, { replacer, stringify2 } from "~packages/util/json"
 
 export class JsonRpcProvider {
   public constructor(public readonly rpcUrl: string) {}
@@ -38,7 +38,7 @@ export class JsonRpcProvider {
     //     id: 0
     // }
     console.log(
-      `[JsonRpcProvider][${args.method}][response] ${JSON.stringify(data)}`
+      `[JsonRpcProvider][${args.method}][response] ${stringify2(data)}`
     )
     // TODO: Transform error to error instance
     return data.result as T

--- a/packages/util/json/index.test.ts
+++ b/packages/util/json/index.test.ts
@@ -1,0 +1,96 @@
+import json, { format, replacer } from "~packages/util/json"
+
+describe("json", () => {
+  const data = {
+    jsonrpc: "1.0",
+    id: 2,
+    x: BigInt("345"),
+    rpIdHash: new Uint8Array([0x06, 0x07, 0x08])
+  }
+
+  it("should format the JSON data using the format() function", () => {
+    const output = format(data)
+
+    expect(output).toBe(`{
+  "jsonrpc": "1.0",
+  "id": 2,
+  "x": 345,
+  "rpIdHash": "060708"
+}`)
+  })
+
+  it("should format the JSON data using the format() function with uint8ArrayToHexString replacer", () => {
+    const output = format(data, replacer.uint8ArrayToHexString)
+
+    expect(output).toBe(`{
+  "jsonrpc": "1.0",
+  "id": 2,
+  "x": 345,
+  "rpIdHash": "060708"
+}`)
+  })
+
+  it("should format the JSON data using the format() function with numberToHex replacer", () => {
+    const output = format(data, replacer.numberToHex)
+
+    expect(output).toBe(`{
+  "jsonrpc": "1.0",
+  "id": "0x2",
+  "x": "0x159",
+  "rpIdHash": "060708"
+}`)
+  })
+
+  it("should format the JSON data using the format() function with custom replacer", () => {
+    const customReplacer = (k: any, v: any) => {
+      if (k === "id") {
+        return v
+      }
+      return replacer.numberToHex(k, v)
+    }
+    const output = format(data, customReplacer)
+
+    expect(output).toBe(`{
+  "jsonrpc": "1.0",
+  "id": 2,
+  "x": "0x159",
+  "rpIdHash": "060708"
+}`)
+  })
+
+  it("should format the JSON data using the json.stringify() function", () => {
+    const output = json.stringify(data)
+
+    expect(output).toBe(
+      `{"jsonrpc":"1.0","id":2,"x":345,"rpIdHash":{"0":6,"1":7,"2":8}}`
+    )
+  })
+
+  it("should format the JSON data using the json.stringify() function with uint8ArrayToHexString replacer", () => {
+    const output = json.stringify(data, replacer.uint8ArrayToHexString)
+
+    expect(output).toBe(`{"jsonrpc":"1.0","id":2,"x":345,"rpIdHash":"060708"}`)
+  })
+
+  it("should format the JSON data using the json.stringify() function with numberToHex replacer", () => {
+    const output = json.stringify(data, replacer.numberToHex)
+
+    expect(output).toBe(
+      `{"jsonrpc":"1.0","id":"0x2","x":"0x159","rpIdHash":{"0":"0x6","1":"0x7","2":"0x8"}}`
+    )
+  })
+
+  it("should format the JSON data using the json.stringify() function with custom replacer", () => {
+    const customReplacer = (k: any, v: any) => {
+      if (k === "id") {
+        return v
+      }
+      return replacer.numberToHex(k, v)
+    }
+    const output = json.stringify(data, customReplacer)
+
+    expect(output).toBe(
+      `{"jsonrpc":"1.0","id":2,"x":"0x159","rpIdHash":{"0":"0x6","1":"0x7","2":"0x8"}}`
+    )
+  })
+})

--- a/packages/util/json/index.ts
+++ b/packages/util/json/index.ts
@@ -23,8 +23,15 @@ export const replacer = {
 
 export function format(
   data: any,
-  customReplacer: (this: any, key: string, value: any) => any | null = null
+  customReplacer?: (this: any, key: string, value: any) => any
 ): string {
-  const json = JSONB({ useNativeBigInt: true })
-  return json.stringify(data, customReplacer, 2)
+  return json.stringify(
+    data,
+    customReplacer
+      ? (key: string, value: any) => {
+          return replacer.uint8ArrayToHexString(key, customReplacer(key, value))
+        }
+      : replacer.uint8ArrayToHexString,
+    2
+  )
 }

--- a/packages/util/json/index.ts
+++ b/packages/util/json/index.ts
@@ -12,3 +12,11 @@ export const replacer = {
     return v
   }
 }
+
+export function stringify2(
+  data: any,
+  replacer: (this: any, key: string, value: any) => any | null = null
+): string {
+  const json = JSONB({ useNativeBigInt: true })
+  return json.stringify(data, replacer, 2)
+}

--- a/packages/util/json/index.ts
+++ b/packages/util/json/index.ts
@@ -13,7 +13,7 @@ export const replacer = {
   }
 }
 
-export function stringify2(
+export function format(
   data: any,
   replacer: (this: any, key: string, value: any) => any | null = null
 ): string {

--- a/packages/util/json/index.ts
+++ b/packages/util/json/index.ts
@@ -2,7 +2,9 @@ import JSONB from "json-bigint"
 
 import number from "~packages/util/number"
 
-export default JSONB({ useNativeBigInt: true })
+const json = JSONB({ useNativeBigInt: true })
+
+export default json
 
 export const replacer = {
   numberToHex: (_: string, v: any) => {
@@ -12,7 +14,6 @@ export const replacer = {
     return v
   },
   uint8ArrayToHexString: (_: string, v: any) => {
-    // Filtering out properties
     if (v instanceof Uint8Array) {
       return Buffer.from(v).toString("hex")
     }
@@ -22,8 +23,8 @@ export const replacer = {
 
 export function format(
   data: any,
-  replacer: (this: any, key: string, value: any) => any | null = null
+  customReplacer: (this: any, key: string, value: any) => any | null = null
 ): string {
   const json = JSONB({ useNativeBigInt: true })
-  return json.stringify(data, replacer, 2)
+  return json.stringify(data, customReplacer, 2)
 }

--- a/packages/util/json/index.ts
+++ b/packages/util/json/index.ts
@@ -10,6 +10,13 @@ export const replacer = {
       return number.toHex(v)
     }
     return v
+  },
+  uint8ArrayToHexString: (_: string, v: any) => {
+    // Filtering out properties
+    if (v instanceof Uint8Array) {
+      return Buffer.from(v).toString("hex")
+    }
+    return v
   }
 }
 

--- a/packages/waallet/content/provider.ts
+++ b/packages/waallet/content/provider.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events"
 
 import { type BackgroundMessenger } from "~packages/messenger/background"
-import { stringify2 } from "~packages/util/json"
+import { format } from "~packages/util/json"
 import type {
   WebAuthnCreation,
   WebAuthnRequest
@@ -49,7 +49,7 @@ export class WaalletContentProvider extends EventEmitter {
       }
     }
     const res = await this.backgroundMessenger.send(req)
-    console.log(`[provider][createWindow] response: ${stringify2(res)}`)
+    console.log(`[provider][createWindow] response: ${format(res)}`)
     return res
   }
 }

--- a/packages/waallet/content/provider.ts
+++ b/packages/waallet/content/provider.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events"
 
 import { type BackgroundMessenger } from "~packages/messenger/background"
+import { stringify2 } from "~packages/util/json"
 import type {
   WebAuthnCreation,
   WebAuthnRequest
@@ -48,9 +49,7 @@ export class WaalletContentProvider extends EventEmitter {
       }
     }
     const res = await this.backgroundMessenger.send(req)
-    console.log(
-      `[provider][createWindow] response: ${JSON.stringify(res, null, 2)}`
-    )
+    console.log(`[provider][createWindow] response: ${stringify2(res)}`)
     return res
   }
 }

--- a/packages/webAuthn/background/webAuthn.ts
+++ b/packages/webAuthn/background/webAuthn.ts
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill"
 
-import json from "~packages/util/json"
+import { stringify2 } from "~packages/util/json"
 import { PortName } from "~packages/webAuthn/tabs/port"
 import {
   isWebAuthnError,
@@ -102,11 +102,7 @@ const listenToWebAuthnRegistration = () => {
             return reject(message.error)
           }
           console.log(
-            `[background][messaging][window] credential: ${json.stringify(
-              message,
-              null,
-              2
-            )}`
+            `[background][messaging][window] credential: ${stringify2(message)}`
           )
           return resolve(message)
         }
@@ -133,11 +129,7 @@ const listenToWebAuthnAuthentication = () => {
             return reject(message.error)
           }
           console.log(
-            `[background][messaging][window] signature: ${json.stringify(
-              message,
-              null,
-              2
-            )}`
+            `[background][messaging][window] signature: ${stringify2(message)}`
           )
           return resolve(message)
         }

--- a/packages/webAuthn/background/webAuthn.ts
+++ b/packages/webAuthn/background/webAuthn.ts
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill"
 
-import { stringify2 } from "~packages/util/json"
+import { format } from "~packages/util/json"
 import { PortName } from "~packages/webAuthn/tabs/port"
 import {
   isWebAuthnError,
@@ -102,7 +102,7 @@ const listenToWebAuthnRegistration = () => {
             return reject(message.error)
           }
           console.log(
-            `[background][messaging][window] credential: ${stringify2(message)}`
+            `[background][messaging][window] credential: ${format(message)}`
           )
           return resolve(message)
         }
@@ -129,7 +129,7 @@ const listenToWebAuthnAuthentication = () => {
             return reject(message.error)
           }
           console.log(
-            `[background][messaging][window] signature: ${stringify2(message)}`
+            `[background][messaging][window] signature: ${format(message)}`
           )
           return resolve(message)
         }

--- a/packages/webAuthn/content/webAuthn.ts
+++ b/packages/webAuthn/content/webAuthn.ts
@@ -1,6 +1,6 @@
 import { runtime, type Runtime } from "webextension-polyfill"
 
-import { stringify2 } from "~packages/util/json"
+import { format } from "~packages/util/json"
 import { createWebAuthn, requestWebAuthn } from "~packages/webAuthn"
 import { PortName } from "~packages/webAuthn/tabs/port"
 import type {
@@ -18,15 +18,11 @@ export const contentCreateWebAuthn = async (
     name: PortName.port_createWebAuthn
   })
   try {
-    console.log(
-      `[content][message][createWebAuthn] params: ${stringify2(params)}`
-    )
+    console.log(`[content][message][createWebAuthn] params: ${format(params)}`)
     const cred = await createWebAuthn(params)
-    console.log(`[content][message][createWebAuthn] cred: ${stringify2(cred)}`)
+    console.log(`[content][message][createWebAuthn] cred: ${format(cred)}`)
     port.onMessage.addListener((message) => {
-      console.log(
-        `[content][message][createWebAuthn] port: ${stringify2(message)}`
-      )
+      console.log(`[content][message][createWebAuthn] port: ${format(message)}`)
     })
     // send to background that create this window
     port.postMessage({
@@ -53,14 +49,12 @@ export const contentRequestWebAuthn = async (
     name: PortName.port_requestWebAuthn
   })
   try {
-    console.log(
-      `[content][message][requestWebAuthn] params: ${stringify2(params)}`
-    )
+    console.log(`[content][message][requestWebAuthn] params: ${format(params)}`)
     const sig = await requestWebAuthn(params)
-    console.log(`[content][message][requestWebAuthn] sig: ${stringify2(sig)}`)
+    console.log(`[content][message][requestWebAuthn] sig: ${format(sig)}`)
     port.onMessage.addListener((message) => {
       console.log(
-        `[content][message][requestWebAuthn] port: ${stringify2(message)}`
+        `[content][message][requestWebAuthn] port: ${format(message)}`
       )
     })
     // send to background that create this window

--- a/packages/webAuthn/content/webAuthn.ts
+++ b/packages/webAuthn/content/webAuthn.ts
@@ -1,6 +1,6 @@
 import { runtime, type Runtime } from "webextension-polyfill"
 
-import json from "~packages/util/json"
+import { stringify2 } from "~packages/util/json"
 import { createWebAuthn, requestWebAuthn } from "~packages/webAuthn"
 import { PortName } from "~packages/webAuthn/tabs/port"
 import type {
@@ -19,27 +19,13 @@ export const contentCreateWebAuthn = async (
   })
   try {
     console.log(
-      `[content][message][createWebAuthn] params: ${json.stringify(
-        params,
-        null,
-        2
-      )}`
+      `[content][message][createWebAuthn] params: ${stringify2(params)}`
     )
     const cred = await createWebAuthn(params)
-    console.log(
-      `[content][message][createWebAuthn] cred: ${json.stringify(
-        cred,
-        null,
-        2
-      )}`
-    )
+    console.log(`[content][message][createWebAuthn] cred: ${stringify2(cred)}`)
     port.onMessage.addListener((message) => {
       console.log(
-        `[content][message][createWebAuthn] port: ${json.stringify(
-          message,
-          null,
-          2
-        )}`
+        `[content][message][createWebAuthn] port: ${stringify2(message)}`
       )
     })
     // send to background that create this window
@@ -68,23 +54,13 @@ export const contentRequestWebAuthn = async (
   })
   try {
     console.log(
-      `[content][message][requestWebAuthn] params: ${json.stringify(
-        params,
-        null,
-        2
-      )}`
+      `[content][message][requestWebAuthn] params: ${stringify2(params)}`
     )
     const sig = await requestWebAuthn(params)
-    console.log(
-      `[content][message][requestWebAuthn] sig: ${json.stringify(sig, null, 2)}`
-    )
+    console.log(`[content][message][requestWebAuthn] sig: ${stringify2(sig)}`)
     port.onMessage.addListener((message) => {
       console.log(
-        `[content][message][requestWebAuthn] port: ${json.stringify(
-          message,
-          null,
-          2
-        )}`
+        `[content][message][requestWebAuthn] port: ${stringify2(message)}`
       )
     })
     // send to background that create this window


### PR DESCRIPTION
Since JSON/json.stringify(data, replacer, 2) commonly used for logging, extracted into standalone function.

Note: stringify2() function will not be used outside of console.log(). Exceptions listed:
1. https://github.com/pilagod/waallet-extension/blob/a9d5f04fcf28e99cd56993c8339225bb4b3e1fea/app/page/authorization/userOperation.tsx#L77-L84
2. https://github.com/pilagod/waallet-extension/blob/d965ac423799c4417257b738fdfc81c42b0c9d46/packages/account/PasskeyAccount/passkeyOwnerP256.ts#L94
3. https://github.com/pilagod/waallet-extension/blob/a39ded834cc3bfb908ad4c3d2532532f63144308/packages/rpc/json/provider.ts#L12-L24
4. https://github.com/pilagod/waallet-extension/blob/c4f8a19b77c8cfbd790ff91ab164b1b7432f37ad/packages/util/url/index.ts#L13
5. https://github.com/pilagod/waallet-extension/blob/f01cb6b3b9e2e372871013c510ff6dfc55e533e1/packages/waallet/background/authorizer/userOperation/popup.ts#L42