### PR TITLE
bug: Initialize a blank tokens array during account config setup

### DIFF
--- a/storage/local/index.ts
+++ b/storage/local/index.ts
@@ -39,7 +39,8 @@ export async function getLocalStorage() {
       Object.assign(account, {
         [accountId]: {
           ...a,
-          userOpLog: {}
+          userOpLog: {},
+          tokens: []
         }
       })
     })


### PR DESCRIPTION
## Description
- Fix the error of undefined tokens when switching to the tokens page.