### PR TITLE
Fix send userop

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -115,9 +115,6 @@ async function main() {
     // TODO: Custom nonce user operation may block the whole process
     sentUserOpLogs.forEach(async (sentUserOpLog) => {
       const userOpHash = sentUserOpLog.receipt.userOpHash
-
-      await bundler.wait(userOpHash)
-
       const userOpReceipt = await bundler.getUserOperationReceipt(userOpHash)
       if (!userOpReceipt) {
         return
@@ -128,7 +125,7 @@ async function main() {
           ...sentUserOpLog,
           status: UserOperationStatus.Succeeded,
           receipt: {
-            userOpHash: userOpHash,
+            userOpHash,
             transactionHash: userOpReceipt.receipt.transactionHash,
             blockHash: userOpReceipt.receipt.blockHash,
             blockNumber: number.toHex(userOpReceipt.receipt.blockNumber)
@@ -147,7 +144,7 @@ async function main() {
           ...sentUserOpLog,
           status: UserOperationStatus.Reverted,
           receipt: {
-            userOpHash: userOpHash,
+            userOpHash,
             transactionHash: userOpReceipt.receipt.transactionHash,
             blockHash: userOpReceipt.receipt.blockHash,
             blockNumber: number.toHex(userOpReceipt.receipt.blockNumber),

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "use-cls-state": "^0.0.3",
-        "use-deep-compare-effect": "^1.8.1",
         "uuid": "^9.0.1",
         "webextension-polyfill": "^0.10.0",
         "wouter": "^3.0.0",
@@ -11810,22 +11809,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/use-deep-compare-effect": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
-      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "dequal": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13"
-      }
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -19669,15 +19652,6 @@
       "requires": {
         "class-transformer": "^0.5.1",
         "reflect-metadata": "^0.2.1"
-      }
-    },
-    "use-deep-compare-effect": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
-      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "dequal": "^2.0.2"
       }
     },
     "use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "use-cls-state": "^0.0.3",
-    "use-deep-compare-effect": "^1.8.1",
     "uuid": "^9.0.1",
     "webextension-polyfill": "^0.10.0",
     "wouter": "^3.0.0",

--- a/packages/bundler/provider.ts
+++ b/packages/bundler/provider.ts
@@ -127,6 +127,9 @@ export class BundlerProvider {
       method: BundlerRpcMethod.eth_sendUserOperation,
       params: [userOp.data(), entryPointAddress]
     })
+    if (this.mode === BundlerMode.Manual) {
+      await this.debugSendBundleNow()
+    }
     return userOpHash
   }
 
@@ -135,9 +138,6 @@ export class BundlerProvider {
   }
 
   public async wait(userOpHash: HexString): Promise<HexString> {
-    if (this.mode === BundlerMode.Manual) {
-      await this.debugSendBundleNow()
-    }
     while (true) {
       const res = await new Promise<
         Nullable<{

--- a/packages/waallet/background/provider.ts
+++ b/packages/waallet/background/provider.ts
@@ -111,14 +111,7 @@ export class WaalletBackgroundProvider {
     callGasLimit: HexString
   }> {
     const userOp = new UserOperation(params[0])
-    const { node, bundler, chainId } = this.networkManager.getActive()
-    const { account } = await this.accountManager.getByAddress(
-      userOp.sender,
-      chainId
-    )
-    // Always using nonce on chain to let estimation passed
-    userOp.setNonce(await account.getNonce(node))
-
+    const { bundler } = this.networkManager.getActive()
     const [entryPointAddress] = await bundler.getSupportedEntryPoints()
     const data = await bundler.estimateUserOperationGas(
       userOp,


### PR DESCRIPTION
I found yesterday bundler `sendUserOperation` rpc api only accepts user op whose nonce matches on chain state. So it is no use to let user set nonce when authorization.

* Remove estimate gas fixing nonce feature.
* Refine background listening process from forever blocking.