### PR TITLE
bug: Increase fee estimates to prevent precheck failed errors

### DIFF
--- a/app/page/authorization/userOperation.tsx
+++ b/app/page/authorization/userOperation.tsx
@@ -135,11 +135,12 @@ function UserOperationConfirmation(props: { userOpLog: UserOperationLog }) {
   // TODO: Put it into a dedicated module
   const estimateGasFee = async () => {
     const fee = await provider.getFeeData()
-    const gasPriceWithBuffer = (fee.gasPrice * 120n) / 100n
-    // TODO: maxFeePerGas and maxPriorityFeePerGas too low error
+    const maxFeePerGasBuffer = (fee.maxFeePerGas * 120n) / 100n
+    const maxPriorityFeePerGasBuffer = (fee.maxPriorityFeePerGas * 120n) / 100n
+
     return {
-      maxFeePerGas: gasPriceWithBuffer,
-      maxPriorityFeePerGas: gasPriceWithBuffer
+      maxFeePerGas: maxFeePerGasBuffer,
+      maxPriorityFeePerGas: maxPriorityFeePerGasBuffer
     }
   }
 


### PR DESCRIPTION
1. Raise maxFeePerGas and maxPriorityFeePerGas estimates.
2. Prevent 'precheck failed' errors on Sepolia network bundler.
3. Prevent undefined userOpHash blocking transactions on-chain.