### PR TITLE
Refine tests

### DIFF
--- a/config/test/index.ts
+++ b/config/test/index.ts
@@ -1,17 +1,15 @@
 import * as ethers from "ethers"
-import { v4 as uuidv4 } from "uuid"
 
-import { SingleNetworkManager } from "~packages/network/manager/single"
+import { BundlerMode, BundlerProvider } from "~packages/bundler/provider"
+import { NodeProvider } from "~packages/node/provider"
 
-const networkManager = new SingleNetworkManager({
-  id: uuidv4(),
-  chaindId: 1337,
-  nodeRpcUrl: "http://localhost:8545",
-  bundlerRpcUrl: "http://localhost:3000"
-})
-const { node } = networkManager.getActive()
+const provider = {
+  node: new NodeProvider("http://localhost:8545"),
+  bundler: new BundlerProvider("http://localhost:3000", BundlerMode.Manual)
+}
+const { node } = provider
 
-const account = {
+const wallet = {
   operator: new ethers.Wallet(
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
     node
@@ -56,8 +54,8 @@ const contract = {
 }
 
 export default {
-  account,
   address,
   contract,
-  networkManager
+  provider,
+  wallet
 }

--- a/packages/account/PasskeyAccount/index.test.ts
+++ b/packages/account/PasskeyAccount/index.test.ts
@@ -9,7 +9,7 @@ const owner = new PasskeyOwnerP256()
 
 describeAccountSuite({
   name: "PasskeyAccount",
-  setup: (runner) => {
+  useAccount: (runner) => {
     return PasskeyAccount.initWithFactory(runner, {
       owner,
       salt: number.random(),

--- a/packages/account/PasskeyAccount/index.test.ts
+++ b/packages/account/PasskeyAccount/index.test.ts
@@ -1,4 +1,3 @@
-import config from "~config/test"
 import number from "~packages/util/number"
 import { describeAccountSuite } from "~packages/util/testing/suite/account"
 import { WaalletRpcMethod } from "~packages/waallet/rpc"
@@ -10,11 +9,11 @@ const owner = new PasskeyOwnerP256()
 
 describeAccountSuite({
   name: "PasskeyAccount",
-  useAccount: (runner) => {
-    return PasskeyAccount.initWithFactory(runner, {
+  useAccount: (cfg) => {
+    return PasskeyAccount.initWithFactory(cfg.provider.node, {
       owner,
       salt: number.random(),
-      factoryAddress: config.address.PasskeyAccountFactory
+      factoryAddress: cfg.address.PasskeyAccountFactory
     })
   },
   suite: (ctx) => {
@@ -22,7 +21,7 @@ describeAccountSuite({
       it("should init with existing passkey account", async () => {
         await ctx.topupAccount()
         // Use `initCode`` to deploy account
-        await ctx.provider.request({
+        await ctx.provider.waallet.request({
           method: WaalletRpcMethod.eth_sendTransaction,
           params: [
             {
@@ -30,7 +29,11 @@ describeAccountSuite({
             }
           ]
         })
-        const { node } = config.networkManager.getActive()
+
+        const {
+          provider: { node }
+        } = ctx
+
         const account = await PasskeyAccount.init(node, {
           address: await ctx.account.getAddress(),
           owner

--- a/packages/account/PasskeyAccount/index.test.ts
+++ b/packages/account/PasskeyAccount/index.test.ts
@@ -7,16 +7,16 @@ import { PasskeyOwnerP256 } from "./passkeyOwnerP256"
 
 const owner = new PasskeyOwnerP256()
 
-describeAccountSuite(
-  "PasskeyAccount",
-  (runner) => {
+describeAccountSuite({
+  name: "PasskeyAccount",
+  setup: (runner) => {
     return PasskeyAccount.initWithFactory(runner, {
       owner,
       salt: number.random(),
       factoryAddress: config.address.PasskeyAccountFactory
     })
   },
-  (ctx) => {
+  suite: (ctx) => {
     describe("init", () => {
       // TODO: This test at this moment relies on tests in test bed to deploy the account.
       // It would be better to decouple it.
@@ -36,4 +36,4 @@ describeAccountSuite(
       })
     })
   }
-)
+})

--- a/packages/account/PasskeyAccount/index.test.ts
+++ b/packages/account/PasskeyAccount/index.test.ts
@@ -1,6 +1,7 @@
 import config from "~config/test"
 import number from "~packages/util/number"
 import { describeAccountSuite } from "~packages/util/testing/suite/account"
+import { WaalletRpcMethod } from "~packages/waallet/rpc"
 
 import { PasskeyAccount } from "./index"
 import { PasskeyOwnerP256 } from "./passkeyOwnerP256"
@@ -21,16 +22,25 @@ describeAccountSuite({
       // TODO: This test at this moment relies on tests in test bed to deploy the account.
       // It would be better to decouple it.
       it("should init with existing passkey account", async () => {
+        // Use `initCode`` to deploy account
+        await ctx.provider.request({
+          method: WaalletRpcMethod.eth_sendTransaction,
+          params: [
+            {
+              to: await ctx.account.getAddress()
+            }
+          ]
+        })
         const { node } = config.networkManager.getActive()
-        const a = await PasskeyAccount.init(node, {
+        const account = await PasskeyAccount.init(node, {
           address: await ctx.account.getAddress(),
           owner
         })
-        expect(await a.getAddress()).toBe(await ctx.account.getAddress())
+        expect(await account.getAddress()).toBe(await ctx.account.getAddress())
 
         const credentialId = await PasskeyAccount.getCredentialId(
           node,
-          await a.getAddress()
+          await account.getAddress()
         )
         expect(credentialId).toBe(owner.getCredentialId())
       })

--- a/packages/account/PasskeyAccount/index.test.ts
+++ b/packages/account/PasskeyAccount/index.test.ts
@@ -19,9 +19,8 @@ describeAccountSuite({
   },
   suite: (ctx) => {
     describe("init", () => {
-      // TODO: This test at this moment relies on tests in test bed to deploy the account.
-      // It would be better to decouple it.
       it("should init with existing passkey account", async () => {
+        await ctx.topupAccount()
         // Use `initCode`` to deploy account
         await ctx.provider.request({
           method: WaalletRpcMethod.eth_sendTransaction,

--- a/packages/account/SimpleAccount/index.test.ts
+++ b/packages/account/SimpleAccount/index.test.ts
@@ -4,10 +4,13 @@ import { describeAccountSuite } from "~packages/util/testing/suite/account"
 
 import { SimpleAccount } from "./index"
 
-describeAccountSuite("SimpleAccount", (runner) => {
-  return SimpleAccount.initWithFactory(runner, {
-    ownerPrivateKey: config.account.operator.privateKey,
-    factoryAddress: config.address.SimpleAccountFactory,
-    salt: number.random()
-  })
+describeAccountSuite({
+  name: "SimpleAccount",
+  setup: (runner) => {
+    return SimpleAccount.initWithFactory(runner, {
+      ownerPrivateKey: config.account.operator.privateKey,
+      factoryAddress: config.address.SimpleAccountFactory,
+      salt: number.random()
+    })
+  }
 })

--- a/packages/account/SimpleAccount/index.test.ts
+++ b/packages/account/SimpleAccount/index.test.ts
@@ -6,7 +6,7 @@ import { SimpleAccount } from "./index"
 
 describeAccountSuite({
   name: "SimpleAccount",
-  setup: (runner) => {
+  useAccount: (runner) => {
     return SimpleAccount.initWithFactory(runner, {
       ownerPrivateKey: config.account.operator.privateKey,
       factoryAddress: config.address.SimpleAccountFactory,

--- a/packages/account/SimpleAccount/index.test.ts
+++ b/packages/account/SimpleAccount/index.test.ts
@@ -1,4 +1,3 @@
-import config from "~config/test"
 import number from "~packages/util/number"
 import { describeAccountSuite } from "~packages/util/testing/suite/account"
 
@@ -6,10 +5,10 @@ import { SimpleAccount } from "./index"
 
 describeAccountSuite({
   name: "SimpleAccount",
-  useAccount: (runner) => {
-    return SimpleAccount.initWithFactory(runner, {
-      ownerPrivateKey: config.account.operator.privateKey,
-      factoryAddress: config.address.SimpleAccountFactory,
+  useAccount: (cfg) => {
+    return SimpleAccount.initWithFactory(cfg.provider.node, {
+      ownerPrivateKey: cfg.wallet.operator.privateKey,
+      factoryAddress: cfg.address.SimpleAccountFactory,
       salt: number.random()
     })
   }

--- a/packages/network/manager/single.ts
+++ b/packages/network/manager/single.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid"
+
 import { BundlerMode, BundlerProvider } from "~packages/bundler/provider"
 import type { NetworkManager } from "~packages/network/manager"
 import { NodeProvider } from "~packages/node/provider"
@@ -5,12 +7,16 @@ import { NodeProvider } from "~packages/node/provider"
 export class SingleNetworkManager implements NetworkManager {
   public constructor(
     private network: {
-      id: string
+      id?: string
       chaindId: number
       nodeRpcUrl: string
       bundlerRpcUrl: string
     }
-  ) {}
+  ) {
+    if (!this.network.id) {
+      this.network.id = uuidv4()
+    }
+  }
 
   public get(id: string) {
     if (id !== this.network.id) {

--- a/packages/paymaster/VerifyingPaymaster/index.test.ts
+++ b/packages/paymaster/VerifyingPaymaster/index.test.ts
@@ -1,37 +1,20 @@
 import config from "~config/test"
 import { describeWaalletSuite } from "~packages/util/testing/suite/waallet"
-import { TransactionToUserOperationSender } from "~packages/waallet/background/pool/transaction/sender"
 import { WaalletRpcMethod } from "~packages/waallet/rpc"
 
 import { VerifyingPaymaster } from "./index"
 
 describeWaalletSuite({
   name: "Verifying Paymaster",
-  suite: (ctx) => {
-    const { node } = config.networkManager.getActive()
-
-    const verifyingPaymaster = new VerifyingPaymaster(node, {
+  usePaymaster: async (runner) => {
+    return new VerifyingPaymaster(runner, {
       address: config.address.VerifyingPaymaster,
       ownerPrivateKey: config.account.operator.privateKey,
       expirationSecs: 300
     })
-
-    beforeAll(() => {
-      ctx.provider = ctx.provider.clone({
-        transactionPool: new TransactionToUserOperationSender(
-          ctx.provider.accountManager,
-          ctx.provider.networkManager,
-          async (userOp, forGasEstimation) => {
-            userOp.setPaymasterAndData(
-              await verifyingPaymaster.requestPaymasterAndData(
-                userOp,
-                forGasEstimation
-              )
-            )
-          }
-        )
-      })
-    })
+  },
+  suite: (ctx) => {
+    const { node } = config.networkManager.getActive()
 
     it("should pay for account", async () => {
       const accountBalanceBefore = await node.getBalance(

--- a/packages/paymaster/VerifyingPaymaster/index.test.ts
+++ b/packages/paymaster/VerifyingPaymaster/index.test.ts
@@ -5,62 +5,65 @@ import { WaalletRpcMethod } from "~packages/waallet/rpc"
 
 import { VerifyingPaymaster } from "./index"
 
-describeWaalletSuite("Verifying Paymaster", (ctx) => {
-  const { node } = config.networkManager.getActive()
+describeWaalletSuite({
+  name: "Verifying Paymaster",
+  suite: (ctx) => {
+    const { node } = config.networkManager.getActive()
 
-  const verifyingPaymaster = new VerifyingPaymaster(node, {
-    address: config.address.VerifyingPaymaster,
-    ownerPrivateKey: config.account.operator.privateKey,
-    expirationSecs: 300
-  })
+    const verifyingPaymaster = new VerifyingPaymaster(node, {
+      address: config.address.VerifyingPaymaster,
+      ownerPrivateKey: config.account.operator.privateKey,
+      expirationSecs: 300
+    })
 
-  beforeAll(() => {
-    ctx.provider = ctx.provider.clone({
-      transactionPool: new TransactionToUserOperationSender(
-        ctx.provider.accountManager,
-        ctx.provider.networkManager,
-        async (userOp, forGasEstimation) => {
-          userOp.setPaymasterAndData(
-            await verifyingPaymaster.requestPaymasterAndData(
-              userOp,
-              forGasEstimation
+    beforeAll(() => {
+      ctx.provider = ctx.provider.clone({
+        transactionPool: new TransactionToUserOperationSender(
+          ctx.provider.accountManager,
+          ctx.provider.networkManager,
+          async (userOp, forGasEstimation) => {
+            userOp.setPaymasterAndData(
+              await verifyingPaymaster.requestPaymasterAndData(
+                userOp,
+                forGasEstimation
+              )
             )
-          )
-        }
-      )
-    })
-  })
-
-  it("should pay for account", async () => {
-    const accountBalanceBefore = await node.getBalance(
-      await ctx.account.getAddress()
-    )
-    const paymasterDepositBalanceBefore =
-      await config.contract.entryPoint.balanceOf(
-        config.address.VerifyingPaymaster
-      )
-
-    await ctx.provider.request({
-      method: WaalletRpcMethod.eth_sendTransaction,
-      params: [
-        {
-          to: await ctx.account.getAddress(),
-          value: 0
-        }
-      ]
+          }
+        )
+      })
     })
 
-    const accountBalanceAfter = await node.getBalance(
-      await ctx.account.getAddress()
-    )
-    expect(accountBalanceBefore).toBe(accountBalanceAfter)
-
-    const paymasterDepositBalanceAfter =
-      await config.contract.entryPoint.balanceOf(
-        config.address.VerifyingPaymaster
+    it("should pay for account", async () => {
+      const accountBalanceBefore = await node.getBalance(
+        await ctx.account.getAddress()
       )
-    expect(paymasterDepositBalanceBefore).toBeGreaterThan(
-      paymasterDepositBalanceAfter
-    )
-  })
+      const paymasterDepositBalanceBefore =
+        await config.contract.entryPoint.balanceOf(
+          config.address.VerifyingPaymaster
+        )
+
+      await ctx.provider.request({
+        method: WaalletRpcMethod.eth_sendTransaction,
+        params: [
+          {
+            to: await ctx.account.getAddress(),
+            value: 0
+          }
+        ]
+      })
+
+      const accountBalanceAfter = await node.getBalance(
+        await ctx.account.getAddress()
+      )
+      expect(accountBalanceBefore).toBe(accountBalanceAfter)
+
+      const paymasterDepositBalanceAfter =
+        await config.contract.entryPoint.balanceOf(
+          config.address.VerifyingPaymaster
+        )
+      expect(paymasterDepositBalanceBefore).toBeGreaterThan(
+        paymasterDepositBalanceAfter
+      )
+    })
+  }
 })

--- a/packages/util/testing/suite/account.ts
+++ b/packages/util/testing/suite/account.ts
@@ -17,91 +17,94 @@ export class AccountSuiteContext<T extends Account> {
   public provider: WaalletBackgroundProvider
 }
 
-export function describeAccountSuite<T extends Account>(
-  name: string,
-  setup: (runner: ContractRunner) => Promise<T>,
+export function describeAccountSuite<T extends Account>(option: {
+  name: string
+  setup: (runner: ContractRunner) => Promise<T>
   suite?: (ctx: AccountSuiteContext<T>) => void
-) {
-  describeWaalletSuite(name, (waalletSuiteCtx) => {
-    const { node } = config.networkManager.getActive()
-    const { counter } = config.contract
+}) {
+  describeWaalletSuite({
+    name: option.name,
+    suite: (waalletSuiteCtx) => {
+      const { node } = config.networkManager.getActive()
+      const { counter } = config.contract
 
-    const ctx = new AccountSuiteContext<T>()
+      const ctx = new AccountSuiteContext<T>()
 
-    beforeAll(async () => {
-      ctx.account = await setup(node)
-      // TODO: Fix inconsistency between waallet provider and user operation sender
-      const accountManager = new SingleAccountManager(ctx.account)
-      ctx.provider = waalletSuiteCtx.provider.clone({
-        accountManager,
-        transactionPool: new TransactionToUserOperationSender(
+      beforeAll(async () => {
+        ctx.account = await option.setup(node)
+        // TODO: Fix inconsistency between waallet provider and user operation sender
+        const accountManager = new SingleAccountManager(ctx.account)
+        ctx.provider = waalletSuiteCtx.provider.clone({
           accountManager,
-          config.networkManager
-        )
-      })
-      await (
-        await config.account.operator.sendTransaction({
-          to: await ctx.account.getAddress(),
-          value: ethers.parseEther("1")
+          transactionPool: new TransactionToUserOperationSender(
+            accountManager,
+            config.networkManager
+          )
         })
-      ).wait()
-    })
-
-    it("should get accounts", async () => {
-      const accounts = await ctx.provider.request<HexString>({
-        method: WaalletRpcMethod.eth_accounts
-      })
-      expect(accounts.length).toBeGreaterThan(0)
-      expect(accounts[0]).toBe(await ctx.account.getAddress())
-    })
-
-    it("should request accounts", async () => {
-      const accounts = await ctx.provider.request<HexString>({
-        method: WaalletRpcMethod.eth_requestAccounts
-      })
-      expect(accounts.length).toBeGreaterThan(0)
-      expect(accounts[0]).toBe(await ctx.account.getAddress())
-    })
-
-    it("should estimate gas", async () => {
-      const gas = await ctx.provider.request<HexString>({
-        method: WaalletRpcMethod.eth_estimateGas,
-        params: [
-          {
-            to: await counter.getAddress(),
-            value: 1,
-            data: counter.interface.encodeFunctionData("increment", [])
-          }
-        ]
-      })
-      expect(byte.isHex(gas)).toBe(true)
-      expect(parseInt(gas, 16)).toBeGreaterThan(0)
-    })
-
-    it("should send transaction to contract", async () => {
-      const balanceBefore = await node.getBalance(counter.getAddress())
-      const counterBefore = (await counter.number()) as bigint
-
-      await ctx.provider.request<HexString>({
-        method: WaalletRpcMethod.eth_sendTransaction,
-        params: [
-          {
-            to: await counter.getAddress(),
-            value: 1,
-            data: counter.interface.encodeFunctionData("increment", [])
-          }
-        ]
+        await (
+          await config.account.operator.sendTransaction({
+            to: await ctx.account.getAddress(),
+            value: ethers.parseEther("1")
+          })
+        ).wait()
       })
 
-      const balanceAfter = await node.getBalance(counter.getAddress())
-      expect(balanceAfter - balanceBefore).toBe(1n)
+      it("should get accounts", async () => {
+        const accounts = await ctx.provider.request<HexString>({
+          method: WaalletRpcMethod.eth_accounts
+        })
+        expect(accounts.length).toBeGreaterThan(0)
+        expect(accounts[0]).toBe(await ctx.account.getAddress())
+      })
 
-      const counterAfter = (await counter.number()) as bigint
-      expect(counterAfter - counterBefore).toBe(1n)
-    })
+      it("should request accounts", async () => {
+        const accounts = await ctx.provider.request<HexString>({
+          method: WaalletRpcMethod.eth_requestAccounts
+        })
+        expect(accounts.length).toBeGreaterThan(0)
+        expect(accounts[0]).toBe(await ctx.account.getAddress())
+      })
 
-    if (suite) {
-      suite(ctx)
+      it("should estimate gas", async () => {
+        const gas = await ctx.provider.request<HexString>({
+          method: WaalletRpcMethod.eth_estimateGas,
+          params: [
+            {
+              to: await counter.getAddress(),
+              value: 1,
+              data: counter.interface.encodeFunctionData("increment", [])
+            }
+          ]
+        })
+        expect(byte.isHex(gas)).toBe(true)
+        expect(parseInt(gas, 16)).toBeGreaterThan(0)
+      })
+
+      it("should send transaction to contract", async () => {
+        const balanceBefore = await node.getBalance(counter.getAddress())
+        const counterBefore = (await counter.number()) as bigint
+
+        await ctx.provider.request<HexString>({
+          method: WaalletRpcMethod.eth_sendTransaction,
+          params: [
+            {
+              to: await counter.getAddress(),
+              value: 1,
+              data: counter.interface.encodeFunctionData("increment", [])
+            }
+          ]
+        })
+
+        const balanceAfter = await node.getBalance(counter.getAddress())
+        expect(balanceAfter - balanceBefore).toBe(1n)
+
+        const counterAfter = (await counter.number()) as bigint
+        expect(counterAfter - counterBefore).toBe(1n)
+      })
+
+      if (option.suite) {
+        option.suite(ctx)
+      }
     }
   })
 }

--- a/packages/util/testing/suite/account.ts
+++ b/packages/util/testing/suite/account.ts
@@ -37,6 +37,8 @@ export function describeAccountSuite<A extends Account, P extends Paymaster>(
       })
 
       it("should estimate gas", async () => {
+        await ctx.topupAccount()
+
         const gas = await ctx.provider.request<HexString>({
           method: WaalletRpcMethod.eth_estimateGas,
           params: [
@@ -52,6 +54,8 @@ export function describeAccountSuite<A extends Account, P extends Paymaster>(
       })
 
       it("should send transaction to contract", async () => {
+        await ctx.topupAccount()
+
         const balanceBefore = await node.getBalance(counter.getAddress())
         const counterBefore = (await counter.number()) as bigint
 

--- a/packages/util/testing/suite/account.ts
+++ b/packages/util/testing/suite/account.ts
@@ -1,20 +1,21 @@
 import config from "~config/test"
 import type { Account } from "~packages/account"
-import type { ContractRunner } from "~packages/node"
+import type { Paymaster } from "~packages/paymaster"
 import byte from "~packages/util/byte"
 import { WaalletRpcMethod } from "~packages/waallet/rpc"
 import type { HexString } from "~typing"
 
-import { describeWaalletSuite, WaalletSuiteContext } from "./waallet"
+import {
+  describeWaalletSuite,
+  WaalletSuiteContext,
+  type WaalletSuiteOption
+} from "./waallet"
 
-export function describeAccountSuite<T extends Account>(option: {
-  name: string
-  setup: (runner: ContractRunner) => Promise<T>
-  suite?: (ctx: WaalletSuiteContext<T>) => void
-}) {
+export function describeAccountSuite<A extends Account, P extends Paymaster>(
+  option: WaalletSuiteOption<A, P>
+) {
   describeWaalletSuite({
-    name: option.name,
-    setup: option.setup,
+    ...option,
     suite: (ctx) => {
       const { node } = config.networkManager.getActive()
       const { counter } = config.contract
@@ -73,7 +74,7 @@ export function describeAccountSuite<T extends Account>(option: {
       })
 
       if (option.suite) {
-        option.suite(ctx as WaalletSuiteContext<T>)
+        option.suite(ctx as WaalletSuiteContext<A>)
       }
     }
   })

--- a/packages/util/testing/suite/waallet.ts
+++ b/packages/util/testing/suite/waallet.ts
@@ -8,6 +8,7 @@ import type { ContractRunner } from "~packages/node"
 import type { Paymaster } from "~packages/paymaster"
 import { TransactionToUserOperationSender } from "~packages/waallet/background/pool/transaction/sender"
 import { WaalletBackgroundProvider } from "~packages/waallet/background/provider"
+import type { BigNumberish } from "~typing"
 
 export type WaalletSuiteOption<A extends Account, P extends Paymaster> = {
   name: string
@@ -19,6 +20,16 @@ export type WaalletSuiteOption<A extends Account, P extends Paymaster> = {
 export class WaalletSuiteContext<T extends Account> {
   public account: T
   public provider: WaalletBackgroundProvider
+
+  public async topupAccount(balance?: BigNumberish) {
+    // TODO: Use default paymaster to accelerate
+    return (
+      await config.account.operator.sendTransaction({
+        to: await this.account.getAddress(),
+        value: balance ?? parseEther("1")
+      })
+    ).wait()
+  }
 }
 
 // TODO: Should be able to customize account setup function
@@ -59,13 +70,13 @@ export function describeWaalletSuite<A extends Account, P extends Paymaster>(
         )
       )
 
-      // TODO: Use default paymaster to accelerate
-      await (
-        await config.account.operator.sendTransaction({
-          to: await ctx.account.getAddress(),
-          value: parseEther("1")
-        })
-      ).wait()
+      // // TODO: Use default paymaster to accelerate
+      // await (
+      //   await config.account.operator.sendTransaction({
+      //     to: await ctx.account.getAddress(),
+      //     value: parseEther("1")
+      //   })
+      // ).wait()
     })
 
     if (option.suite) {

--- a/packages/util/testing/suite/waallet.ts
+++ b/packages/util/testing/suite/waallet.ts
@@ -10,11 +10,11 @@ export class WaalletSuiteContext {
 }
 
 // TODO: Should be able to customize account setup function
-export function describeWaalletSuite(
-  name: string,
+export function describeWaalletSuite(option: {
+  name: string
   suite?: (ctx: WaalletSuiteContext) => void
-) {
-  describe(name, () => {
+}) {
+  describe(option.name, () => {
     const ctx = new WaalletSuiteContext()
 
     beforeAll(async () => {
@@ -34,8 +34,8 @@ export function describeWaalletSuite(
       )
     })
 
-    if (suite) {
-      suite(ctx)
+    if (option.suite) {
+      option.suite(ctx)
     }
   })
 }

--- a/packages/util/testing/suite/waallet.ts
+++ b/packages/util/testing/suite/waallet.ts
@@ -1,29 +1,40 @@
+import { parseEther } from "ethers"
+
 import config from "~config/test"
+import type { Account } from "~packages/account"
 import { SingleAccountManager } from "~packages/account/manager/single"
 import { SimpleAccount } from "~packages/account/SimpleAccount"
+import type { ContractRunner } from "~packages/node"
 import { TransactionToUserOperationSender } from "~packages/waallet/background/pool/transaction/sender"
 import { WaalletBackgroundProvider } from "~packages/waallet/background/provider"
 
-export class WaalletSuiteContext {
-  public account: SimpleAccount
+export class WaalletSuiteContext<T extends Account> {
+  public account: T
   public provider: WaalletBackgroundProvider
 }
 
 // TODO: Should be able to customize account setup function
-export function describeWaalletSuite(option: {
+export function describeWaalletSuite<T extends Account>(option: {
   name: string
-  suite?: (ctx: WaalletSuiteContext) => void
+  setup?: (runner: ContractRunner) => Promise<T>
+  suite?: (ctx: WaalletSuiteContext<T>) => void
 }) {
   describe(option.name, () => {
     const ctx = new WaalletSuiteContext()
 
     beforeAll(async () => {
       const { node } = config.networkManager.getActive()
-      ctx.account = await SimpleAccount.init(node, {
-        address: config.address.SimpleAccount,
-        ownerPrivateKey: config.account.operator.privateKey
-      })
+
+      if (option.setup) {
+        ctx.account = await option.setup(node)
+      } else {
+        ctx.account = await SimpleAccount.init(node, {
+          address: config.address.SimpleAccount,
+          ownerPrivateKey: config.account.operator.privateKey
+        })
+      }
       const accountManager = new SingleAccountManager(ctx.account)
+
       ctx.provider = new WaalletBackgroundProvider(
         accountManager,
         config.networkManager,
@@ -32,10 +43,17 @@ export function describeWaalletSuite(option: {
           config.networkManager
         )
       )
+
+      await (
+        await config.account.operator.sendTransaction({
+          to: await ctx.account.getAddress(),
+          value: parseEther("1")
+        })
+      ).wait()
     })
 
     if (option.suite) {
-      option.suite(ctx)
+      option.suite(ctx as WaalletSuiteContext<T>)
     }
   })
 }

--- a/packages/waallet/background/provider.test.ts
+++ b/packages/waallet/background/provider.test.ts
@@ -41,6 +41,8 @@ describeWaalletSuite({
     })
 
     it("should estimate gas", async () => {
+      await ctx.topupAccount()
+
       const gas = await ctx.provider.request<HexString>({
         method: WaalletRpcMethod.eth_estimateGas,
         params: [
@@ -56,6 +58,8 @@ describeWaalletSuite({
     })
 
     it("should fail to estimate user operation when nonce doesn't match the one on chain", async () => {
+      await ctx.topupAccount()
+
       const userOp = await ctx.account.createUserOperation({
         to: await counter.getAddress(),
         value: 1,
@@ -78,6 +82,8 @@ describeWaalletSuite({
     })
 
     it("should send transaction to contract", async () => {
+      await ctx.topupAccount()
+
       const balanceBefore = await node.getBalance(counter.getAddress())
       const counterBefore = (await counter.number()) as bigint
 
@@ -102,6 +108,8 @@ describeWaalletSuite({
     })
 
     it("should send user operation", async () => {
+      await ctx.topupAccount()
+
       const { bundler, node } = ctx.provider.networkManager.getActive()
 
       const counterBefore = (await counter.number()) as bigint


### PR DESCRIPTION
This PR is based on #123 

* Isolated each test without affecting others
* Use manual topup (`ctx.topupAccount`) when account needs balance to send tx, in order to speed up test running (80 sec -> 50 sec)
* Refine context usage, avoid importing config directly in tests.