### PR TITLE
Fix path resolve failure when plasmo build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "engines": {
     "node": ">=18"
   },
+  "targets": {
+    "default": {
+      "engines": {
+        "browsers": "last 2 versions, not dead, > 0.2%"
+      }
+    }
+  },
   "scripts": {
     "dev": "plasmo dev --env .env.development",
     "build": "plasmo build",


### PR DESCRIPTION
# Description
- When `npm run build`, it shows the error with `Failed with resolve...`
![image](https://github.com/pilagod/waallet-extension/assets/61860963/a8dad7f4-d2db-411b-ab1b-8a73877303b4)
- Same [issue](https://github.com/PlasmoHQ/plasmo/issues/750) raised from plasmo
- **Workaround**
  - remove `engines.node` 
  - or add targets

# Changes
- Add targets and specify "last 2 versions, not dead, > 0.2%" (This could be changed when we are about to release, [ref](https://github.com/browserslist/browserslist?tab=readme-ov-file#full-list))
- Build successfully
  - ![截圖 2024-07-03 中午12 08 30](https://github.com/pilagod/waallet-extension/assets/61860963/44b5f7bf-09c4-43c7-a5a2-ed815ec62515)
