### PR TITLE
Switch account & network in authorization

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -50,11 +50,10 @@ function PageRouter() {
     window.scrollTo(0, 0)
   }, [location])
 
-  const pendingTxs = usePendingTransactions()
-  if (
-    pendingTxs.length > 0 &&
-    !location.startsWith(Path.TransactionAuthorization)
-  ) {
+  const hasPendingTx = useStorage(
+    useShallow(({ state }) => Object.keys(state.pendingTransaction).length > 0)
+  )
+  if (hasPendingTx && !location.startsWith(Path.TransactionAuthorization)) {
     navigate(Path.TransactionAuthorization)
     return
   }

--- a/app/page/authorization/transaction.tsx
+++ b/app/page/authorization/transaction.tsx
@@ -42,6 +42,7 @@ export function TransactionAuthorization() {
     return
   }
   const [tx] = pendingTxs
+
   return (
     <ProfileSwithcher accountId={tx.senderId} networkId={tx.networkId}>
       <TransactionConfirmation tx={tx} />
@@ -219,6 +220,7 @@ function UserOperationConfirmation(props: {
 
   useEffect(() => {
     async function setupUserOp() {
+      setUserOp(null)
       const transactionType = getERC4337TransactionType(
         tx.networkId,
         await sender.getEntryPoint()

--- a/app/page/authorization/transaction.tsx
+++ b/app/page/authorization/transaction.tsx
@@ -59,16 +59,16 @@ function ProfileSwithcher(props: {
 
   const { switchProfile } = useAction()
 
-  const [switchingProfile, setSwitchingProfile] = useState(false)
+  const [profileSwitching, setProfileSwitching] = useState(false)
 
   useEffect(() => {
-    setSwitchingProfile(true)
+    setProfileSwitching(true)
     switchProfile({ accountId, networkId }).then(() => {
-      setSwitchingProfile(false)
+      setProfileSwitching(false)
     })
   }, [accountId, networkId])
 
-  if (switchingProfile) {
+  if (profileSwitching) {
     return
   }
 

--- a/app/page/authorization/transaction.tsx
+++ b/app/page/authorization/transaction.tsx
@@ -111,7 +111,6 @@ function UserOperationConfirmation(props: {
 }) {
   const { tx, sender, network } = props
 
-  const [, navigate] = useHashLocation()
   const { provider } = useProviderContext()
 
   const paymentOptions: PaymentOption[] = [
@@ -172,6 +171,7 @@ function UserOperationConfirmation(props: {
       if (!userOpHash) {
         throw new Error("Fail to send user operation")
       }
+      // TODO: Wrong nonce problem when confirming consecutive pending tx
       await markERC4337TransactionSent(tx.id, {
         entryPoint,
         userOp,
@@ -180,6 +180,7 @@ function UserOperationConfirmation(props: {
     } catch (e) {
       // TOOD: Show error on page
       console.error(e)
+    } finally {
       setUserOpResolving(false)
     }
   }
@@ -191,9 +192,9 @@ function UserOperationConfirmation(props: {
         entryPoint: await sender.getEntryPoint(),
         userOp
       })
-      navigate(Path.Index)
     } catch (e) {
       console.error(e)
+    } finally {
       setUserOpResolving(false)
     }
   }
@@ -231,7 +232,7 @@ function UserOperationConfirmation(props: {
       setUserOp(userOp)
     }
     setupUserOp()
-  }, [])
+  }, [tx.id])
 
   useEffect(() => {
     async function estimateUserOp() {
@@ -265,7 +266,7 @@ function UserOperationConfirmation(props: {
   }, [JSON.stringify(userOp?.unwrap())])
 
   if (!userOp) {
-    return <></>
+    return
   }
 
   return (

--- a/app/page/authorization/transaction.tsx
+++ b/app/page/authorization/transaction.tsx
@@ -41,8 +41,37 @@ export function TransactionAuthorization() {
     navigate(Path.Index)
     return
   }
-  // TODO: Should switch active network for each transaction
-  return <TransactionConfirmation tx={pendingTxs[0]} />
+  const [tx] = pendingTxs
+  return (
+    <ProfileSwithcher accountId={tx.senderId} networkId={tx.networkId}>
+      <TransactionConfirmation tx={tx} />
+    </ProfileSwithcher>
+  )
+}
+
+function ProfileSwithcher(props: {
+  accountId: string
+  networkId: string
+  children: React.ReactNode
+}) {
+  const { accountId, networkId, children } = props
+
+  const { switchProfile } = useAction()
+
+  const [switchingProfile, setSwitchingProfile] = useState(false)
+
+  useEffect(() => {
+    setSwitchingProfile(true)
+    switchProfile({ accountId, networkId }).then(() => {
+      setSwitchingProfile(false)
+    })
+  }, [accountId, networkId])
+
+  if (switchingProfile) {
+    return
+  }
+
+  return children
 }
 
 function TransactionConfirmation(props: { tx: TransactionPending }) {

--- a/app/storage/index.ts
+++ b/app/storage/index.ts
@@ -108,6 +108,14 @@ export const useStorage = create<Storage>()(
         ) {
           return
         }
+        if (
+          state.network[profile.networkId].chainId !==
+          state.account[profile.accountId].chainId
+        ) {
+          throw new Error(
+            `Account ${profile.accountId} doesn't exist in network ${profile.networkId}`
+          )
+        }
         await set(({ state }) => {
           state.networkActive = profile.networkId
           state.network[profile.networkId].accountActive = profile.accountId

--- a/app/storage/index.ts
+++ b/app/storage/index.ts
@@ -25,18 +25,16 @@ import { background } from "./middleware/background"
 
 const storageMessenger = new StorageMessenger()
 
-type Profile = {
-  accountId: string
-  networkId: string
-}
-
 // TODO: Split as slices
 interface Storage {
   state: State
 
   /* Profile */
 
-  switchProfile: (profile: Profile) => Promise<void>
+  switchProfile: (profile: {
+    accountId: string
+    networkId: string
+  }) => Promise<void>
 
   /* Account */
 
@@ -97,7 +95,10 @@ export const useStorage = create<Storage>()(
 
       /* Profile */
 
-      switchProfile: async (profile: Profile) => {
+      switchProfile: async (profile: {
+        accountId: string
+        networkId: string
+      }) => {
         const { state } = get()
         const networkId = state.networkActive
         const accountId = state.network[networkId].accountActive

--- a/app/storage/index.ts
+++ b/app/storage/index.ts
@@ -25,9 +25,18 @@ import { background } from "./middleware/background"
 
 const storageMessenger = new StorageMessenger()
 
+type Profile = {
+  accountId: string
+  networkId: string
+}
+
 // TODO: Split as slices
 interface Storage {
   state: State
+
+  /* Profile */
+
+  switchProfile: (profile: Profile) => Promise<void>
 
   /* Account */
 
@@ -85,6 +94,24 @@ export const useStorage = create<Storage>()(
   background(
     (set, get) => ({
       state: null,
+
+      /* Profile */
+
+      switchProfile: async (profile: Profile) => {
+        const { state } = get()
+        const networkId = state.networkActive
+        const accountId = state.network[networkId].accountActive
+        if (
+          accountId === profile.accountId &&
+          networkId === profile.networkId
+        ) {
+          return
+        }
+        await set(({ state }) => {
+          state.networkActive = profile.networkId
+          state.network[profile.networkId].accountActive = profile.accountId
+        })
+      },
 
       /* Account */
 


### PR DESCRIPTION
1. Switch account & network for each pending tx
> Although I didn't figure out a way to simulate the case of multiple pending txs with different account and network, it is more confident to explicitly change account & network before confirming each pending tx
2. Enhance rendering process of handling pending tx, avoid frequently re-rendering the root App.