### PR TITLE
Wait for userOpEstimating to finish

### DIFF
--- a/app/page/authorization/transaction.tsx
+++ b/app/page/authorization/transaction.tsx
@@ -265,7 +265,7 @@ function UserOperationConfirmation(props: {
                 id={id}
                 name={o.name}
                 checked={isSelected}
-                disabled={paymentCalculating || isSelected}
+                disabled={paymentCalculating || isSelected || userOpEstimating}
                 onChange={() => setPaymentOption(o)}
               />
               <label htmlFor={id}>{o.name}</label>


### PR DESCRIPTION
## Description
1. PaymentCalculating completes faster than userOpEstimating.
2. Wait for userOpEstimating to finish before switching Paymaster, or the Popup will show outdated information.