### PR TITLE
Refine Select token

### DIFF
--- a/app/component/tokenItem.tsx
+++ b/app/component/tokenItem.tsx
@@ -12,7 +12,7 @@ export const TokenItem = ({
 }) => {
   return (
     <button className="w-full" onClick={onClick}>
-      <div className="flex items-center py-[13.5px]">
+      <div className="flex items-center py-[17px]">
         <Ethereum className="w-[36px] h-[36px] mr-[12px]" />
         <div className="flex-grow text-[20px] text-[#000000] text-left whitespace-nowrap">
           {token.symbol}

--- a/app/component/tokenItem.tsx
+++ b/app/component/tokenItem.tsx
@@ -1,0 +1,30 @@
+import Ethereum from "react:~assets/ethereum.svg"
+
+import number from "~packages/util/number"
+import type { Token } from "~storage/local/state"
+
+export const TokenItem = ({
+  token,
+  onClick
+}: {
+  token: Token
+  onClick: () => void
+}) => {
+  return (
+    <button className="w-full" onClick={onClick}>
+      <div className="flex items-center py-[13.5px]">
+        <Ethereum className="w-[36px] h-[36px] mr-[12px]" />
+        <div className="flex-grow text-[20px] text-[#000000] text-left whitespace-nowrap">
+          {token.symbol}
+        </div>
+        <div className="flex flex-col items-end">
+          <div className="mb-[4px] text-[20px] font-[600] text-[#000000]">
+            {number.formatUnitsToFixed(token.balance, token.decimals, 2)}
+          </div>
+          {/* // TODO: add price oracle */}
+          <div className="text-[12px] text-[#000000]">$1.23</div>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/app/component/tokenList.tsx
+++ b/app/component/tokenList.tsx
@@ -1,3 +1,13 @@
-export const TokenList = ({ children }: { children: React.ReactNode }) => {
-  return <div className="w-full flex flex-col items-start">{children}</div>
+export const TokenList = ({
+  children,
+  className
+}: {
+  children: React.ReactNode
+  className?: string
+}) => {
+  return (
+    <div className={`w-full flex flex-col items-start ${className}`}>
+      {children}
+    </div>
+  )
 }

--- a/app/component/tokenList.tsx
+++ b/app/component/tokenList.tsx
@@ -1,0 +1,3 @@
+export const TokenList = ({ children }: { children: React.ReactNode }) => {
+  return <div className="w-full flex flex-col items-start">{children}</div>
+}

--- a/app/context/sendTokenContext.tsx
+++ b/app/context/sendTokenContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useState, type ReactNode } from "react"
+
+import { useAccount, useTokens } from "~app/storage"
+import { getChainName } from "~packages/network/util"
+import type { Token } from "~storage/local/state"
+import type { Nullable } from "~typing"
+
+type SendTokenContextType = {
+  tokens: Token[]
+  tokenSelected: Nullable<Token>
+  setTokenSelected: (token: Token) => void
+  step: number
+  setStep: (step: number) => void
+}
+
+export const SendTokenContext =
+  createContext<Nullable<SendTokenContextType>>(null)
+
+export const SendTokenProvider = ({ children }: { children: ReactNode }) => {
+  const account = useAccount()
+  const nativeToken = {
+    address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    symbol: `${getChainName(account.chainId)}ETH`,
+    decimals: 18,
+    balance: account.balance
+  }
+  const tokens = [nativeToken, ...useTokens()]
+  const [tokenSelected, setTokenSelected] = useState<Nullable<Token>>(null)
+  const [step, setStep] = useState<number>(0)
+
+  return (
+    <SendTokenContext.Provider
+      value={{
+        tokens,
+        tokenSelected,
+        setTokenSelected,
+        step,
+        setStep
+      }}>
+      {children}
+    </SendTokenContext.Provider>
+  )
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -17,6 +17,7 @@ import { useStorage } from "~app/storage"
 import "~style.css"
 
 import { Toast } from "./component/toast"
+import { SendTokenContext, SendTokenProvider } from "./context/sendTokenContext"
 import { ToastProvider } from "./context/toastContext"
 
 export function App() {
@@ -41,11 +42,13 @@ export function App() {
   return (
     <ProviderContextProvider>
       <ToastProvider>
-        {/* Waallet popup script page */}
-        <div className="w-[390px] h-[600px] px-[16px] pt-[20px]">
-          <Toast />
-          <PageRouter />
-        </div>
+        <SendTokenProvider>
+          {/* Waallet popup script page */}
+          <div className="w-[390px] h-[600px] px-[16px] pt-[20px]">
+            <Toast />
+            <PageRouter />
+          </div>
+        </SendTokenProvider>
       </ToastProvider>
     </ProviderContextProvider>
   )

--- a/app/page/home/token.tsx
+++ b/app/page/home/token.tsx
@@ -1,10 +1,11 @@
 import { faCaretDown, faXmark } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { getAddress, parseUnits, toNumber } from "ethers"
-import Ethereum from "react:~assets/ethereum.svg"
 import { Link } from "wouter"
 import { useContext, useState, type ChangeEvent } from "react"
 
+import { TokenItem } from "~app/component/tokenItem"
+import { TokenList } from "~app/component/tokenList"
 import { useProviderContext } from "~app/context/provider"
 import { SendTokenContext } from "~app/context/sendTokenContext"
 import { ToastContext } from "~app/context/toastContext"
@@ -33,74 +34,33 @@ export function Token() {
     useContext(SendTokenContext)
 
   return (
-    <>
-      {/* Home page token list */}
-      <div className="w-full flex flex-col items-start">
-        {/* Native token cell */}
-        <Link
-          className="w-full flex items-center p-[13.5px_0px_13.5px_0px]"
-          href={Path.Send}>
-          {/* Native token image */}
-          <Ethereum className="w-[36px] h-[36px] mr-[12px]" />
-          {/* Native token symbol */}
-          <div className="flex-grow leading-[24px] text-[20px] text-[#000000] text-left whitespace-nowrap">
-            {`${getChainName(account.chainId)}ETH`}
-          </div>
-          {/* Native token balance */}
-          <div className="flex flex-col items-end">
-            <div className="mb-[4px] leading-[24.5px] text-[20px] font-[600] text-[#000000]">
-              {number.formatUnitsToFixed(account.balance, 18, 2)}
-            </div>
-            <div className="leading-[14.5px] text-[12px] text-[#000000]">
-              $1.23
-            </div>
-          </div>
-        </Link>
-        {/* Token cell */}
-        {tokens.map((token, index) => {
-          return (
-            <button
-              className="w-full flex items-center p-[13.5px_0px_13.5px_0px]"
-              onClick={() => openTokenInfoModal(token.address)}
-              key={index}>
-              {/* Token image */}
-              <Ethereum className="w-[36px] h-[36px] mr-[12px]" />
-              {/* Token symbol */}
-              <div className="flex-grow leading-[24px] text-[20px] text-[#000000] text-left whitespace-nowrap">
-                {token.symbol}
-              </div>
-              {/* Token balance */}
-              <div className="flex flex-col items-end">
-                <div className="mb-[4px] leading-[24.5px] text-[20px] font-[600] text-[#000000]">
-                  {number.formatUnitsToFixed(token.balance, token.decimals, 2)}
-                </div>
-                <div className="leading-[14.5px] text-[12px] text-[#000000]">
-                  $1000.00
-                </div>
-              </div>
-            </button>
-          )
-        })}
-        {/* Token information modal */}
-        {selectedTokenAddress && (
-          <TokenInfoModal
-            onModalClosed={closeTokenInfoModal}
-            tokenAddress={selectedTokenAddress}
-          />
-        )}
-        {/* Token importing button */}
-        <div
-          className="col-span-3 cursor-pointer"
-          onClick={toggleTokenImportModal}>
-          <span>Import Tokens</span>
-          <FontAwesomeIcon icon={faCaretDown} className="ml-2" />
-        </div>
-        {/* Token importing modal */}
-        {isTokenImportModalOpened && (
-          <TokenImportModal onModalClosed={toggleTokenImportModal} />
-        )}
+    <TokenList>
+      {tokens.map((token, index) => (
+        <TokenItem
+          token={token}
+          key={index}
+          onClick={() => openTokenInfoModal(token)}
+        />
+      ))}
+      {/* Token information modal */}
+      {tokenSelected && (
+        <TokenInfoModal
+          onModalClosed={closeTokenInfoModal}
+          tokenAddress={tokenSelected.address}
+        />
+      )}
+      {/* Token importing button */}
+      <div
+        className="col-span-3 cursor-pointer"
+        onClick={toggleTokenImportModal}>
+        <span>Import Tokens</span>
+        <FontAwesomeIcon icon={faCaretDown} className="ml-2" />
       </div>
-    </>
+      {/* Token importing modal */}
+      {isTokenImportModalOpened && (
+        <TokenImportModal onModalClosed={toggleTokenImportModal} />
+      )}
+    </TokenList>
   )
 }
 

--- a/app/page/home/token.tsx
+++ b/app/page/home/token.tsx
@@ -1,8 +1,8 @@
 import { faCaretDown, faXmark } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { getAddress, parseUnits, toNumber } from "ethers"
-import { Link } from "wouter"
+import { getAddress, toNumber } from "ethers"
 import { useContext, useState, type ChangeEvent } from "react"
+import { useHashLocation } from "wouter/use-hash-location"
 
 import { TokenItem } from "~app/component/tokenItem"
 import { TokenList } from "~app/component/tokenList"
@@ -81,8 +81,6 @@ function TokenInfoModal({
   const [tokenSymbol, setTokenSymbol] = useState<string>(tokenSelected.symbol)
   const [invalidTokenSymbol, setInvalidTokenSymbol] = useState<boolean>(false)
   const [isViewExplorerVisible, setIsViewExplorerVisible] = useState(false)
-  const [isTokenSendModalOpened, setIsTokenSendModalOpened] =
-    useState<boolean>(false)
 
   const toggleViewExplorerVisibility = () => {
     setIsViewExplorerVisible((prev) => !prev)
@@ -110,9 +108,11 @@ function TokenInfoModal({
   const handleClose = () => {
     onModalClosed()
   }
+  const [, navigate] = useHashLocation()
 
-  const toggleTokenSendModal = () => {
-    setIsTokenSendModalOpened((prev) => !prev)
+  const handleSend = () => {
+    setStep(1)
+    navigate(Path.Send)
   }
 
   return (
@@ -191,158 +191,18 @@ function TokenInfoModal({
           <button type="button" onClick={handleRemove}>
             Remove
           </button>
-          <button type="button" onClick={toggleTokenSendModal}>
+          <button type="button" onClick={handleSend}>
             Send
           </button>
           <button type="button" onClick={handleClose}>
             Close
           </button>
         </div>
-        {isTokenSendModalOpened && (
-          <TokenSendModal
-            onModalClosed={toggleTokenSendModal}
-            tokenAddress={tokenAddress}
-          />
-        )}
       </div>
     </div>
   )
 }
 
-function TokenSendModal({
-  onModalClosed,
-  tokenAddress
-}: {
-  onModalClosed: () => void
-  tokenAddress: HexString
-}) {
-  const { provider } = useProviderContext()
-  const account = useAccount()
-  const tokens = useTokens()
-  const token = tokens.find((token) =>
-    address.isEqual(token.address, tokenAddress)
-  )
-
-  const [inputTo, setInputTo] = useState<string>("")
-  const [inputValue, setInputValue] = useState<string>("")
-  const [invalidTo, setInvalidTo] = useState<boolean>(false)
-  const [invalidValue, setInvalidValue] = useState<boolean>(false)
-
-  const handleClose = () => {
-    onModalClosed()
-  }
-
-  const handleToChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value
-    setInputTo(value)
-    try {
-      console.log(`${getAddress(value)}`)
-      setInvalidTo(false)
-    } catch (error) {
-      console.warn(`Invalid to address: ${error}`)
-      setInvalidTo(true)
-    }
-  }
-
-  const handleAmountChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value
-    setInputValue(value)
-    try {
-      console.log(`${parseUnits(value, token.decimals)}`)
-      setInvalidValue(false)
-    } catch (error) {
-      console.warn(`Invalid value: ${error}`)
-      setInvalidValue(true)
-    }
-  }
-
-  const handleSend = useCallback(async () => {
-    const erc20 = getErc20Contract(token.address, provider)
-
-    try {
-      const data = erc20.interface.encodeFunctionData("transfer", [
-        inputTo,
-        parseUnits(inputValue.toString(), token.decimals)
-      ])
-
-      const signer = await provider.getSigner()
-      const { hash } = await signer.sendTransaction({
-        to: token.address,
-        value: 0,
-        data: data
-      })
-
-      console.log(`[Popup][TokenSendModal] transaction hash: ${hash}`)
-    } catch (error) {
-      console.warn(`[Popup][TokenSendModal] send transaction error: ${error}`)
-    }
-  }, [inputTo, inputValue])
-
-  return (
-    <div className="absolute top-0 left-0 w-screen h-screen p-4">
-      <div
-        className="absolute top-0 left-0 w-full h-full bg-black/75"
-        onClick={onModalClosed}
-      />
-      <div className="relative w-full p-4 bg-white rounded">
-        <div className="absolute top-4 right-4">
-          <button onClick={onModalClosed}>
-            <FontAwesomeIcon icon={faXmark} className="text-lg" />
-          </button>
-        </div>
-        <div>
-          <label htmlFor="asset">Asset:</label>
-          <input
-            type="text"
-            id="asset"
-            value={token.symbol}
-            disabled={true}
-            className="border w-96 outline-none border-gray-300"
-          />
-        </div>
-        <div>
-          <label htmlFor="to">To:</label>
-          <input
-            type="text"
-            id="to"
-            value={`${inputTo}`}
-            onChange={handleToChange}
-            list="suggestionTo"
-            className={`border w-96 outline-none ${
-              invalidTo ? "border-red-500" : "border-gray-300"
-            }`}
-          />
-          <datalist id="suggestionTo">
-            <option value={account.address} />
-          </datalist>
-        </div>
-        <div>
-          <label htmlFor="amount">Amount:</label>
-          <input
-            type="text"
-            id="amount"
-            value={`${inputValue}`}
-            onChange={handleAmountChange}
-            className={`border w-96 outline-none ${
-              invalidValue ? "border-red-500" : "border-gray-300"
-            }`}
-          />
-        </div>
-        <div className="w-full grid grid-cols-5 justify-items-center my-4 text-base">
-          <button
-            onClick={handleSend}
-            disabled={invalidTo || invalidValue}
-            className="flex-1">
-            Send
-          </button>
-          <button type="button" onClick={handleClose}>
-            Cancel
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
 function TokenImportModal({ onModalClosed }: { onModalClosed: () => void }) {
   const { provider } = useProviderContext()
   const { importToken } = useAction()

--- a/app/page/send/index.tsx
+++ b/app/page/send/index.tsx
@@ -3,6 +3,8 @@ import { useCallback, useContext, useState, type ChangeEvent } from "react"
 import { Link } from "wouter"
 
 import { StepBackHeader } from "~app/component/stepBackHeader"
+import { TokenItem } from "~app/component/tokenItem"
+import { TokenList } from "~app/component/tokenList"
 import { useProviderContext } from "~app/context/provider"
 import { SendTokenContext } from "~app/context/sendTokenContext"
 import { Path } from "~app/path"
@@ -21,26 +23,15 @@ const SelectToken = ({ tokens, onSelectToken }) => {
   }
 
   return (
-    <div className="flex">
-      <label className="col-span-1">Asset:</label>
-      <select
-        id="asset"
-        value={tokens[0].address}
-        className="col-span-4 border w-full outline-none border-gray-300"
-        onChange={handleAssetChange}>
-        {tokens.map((token) => {
-          const balance = number.formatUnitsToFixed(
-            token.balance,
-            token.decimals
-          )
-          return (
-            <option key={token.address} value={token.address}>
-              {token.symbol}: {balance} {token.symbol}
-            </option>
-          )
-        })}
-      </select>
-    </div>
+      <TokenList>
+        {tokens.map((token, index) => (
+          <TokenItem
+            key={index}
+            token={token}
+            onClick={() => handleOnSelectToken(token)}
+          />
+        ))}
+      </TokenList>
   )
 }
 

--- a/app/page/send/index.tsx
+++ b/app/page/send/index.tsx
@@ -20,7 +20,7 @@ const SelectToken = () => {
   return (
     <>
       <StepBackHeader title="Select Token" href={Path.Index} />
-      <TokenList>
+      <TokenList className="pt-[16px]">
         {tokens.map((token, index) => (
           <TokenItem
             key={index}

--- a/app/page/send/index.tsx
+++ b/app/page/send/index.tsx
@@ -1,14 +1,14 @@
 import * as ethers from "ethers"
-import { useCallback, useState, type ChangeEvent } from "react"
+import { useCallback, useContext, useState, type ChangeEvent } from "react"
 import { Link } from "wouter"
 
 import { StepBackHeader } from "~app/component/stepBackHeader"
 import { useProviderContext } from "~app/context/provider"
+import { SendTokenContext } from "~app/context/sendTokenContext"
 import { Path } from "~app/path"
-import { useAccount, useTokens } from "~app/storage"
-import { getChainName, getErc20Contract } from "~packages/network/util"
+import { useAccount } from "~app/storage"
+import { getErc20Contract } from "~packages/network/util"
 import address from "~packages/util/address"
-import number from "~packages/util/number"
 import { type Token } from "~storage/local/state"
 import type { BigNumberish, HexString } from "~typing"
 
@@ -111,18 +111,10 @@ const SendAmount = ({ amount, onChangeAmount }) => {
 
 export function Send() {
   const { provider } = useProviderContext()
-  const account = useAccount()
-  const nativeToken: Token = {
-    address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-    symbol: `${getChainName(account.chainId)}ETH`,
-    decimals: 18,
-    balance: account.balance
-  }
-  const tokens = [nativeToken, ...useTokens()]
-  const [token, setToken] = useState<Token>(tokens[0])
+
+  const { tokens, tokenSelected, step, setStep } = useContext(SendTokenContext)
   const [txTo, setTxTo] = useState<HexString>("")
   const [txValue, setTxValue] = useState<BigNumberish>("0")
-  const [step, setStep] = useState<number>(0)
 
   const stepsComponents = [
     <SelectToken key="step1" tokens={tokens} onSelectToken={setToken} />,


### PR DESCRIPTION
# Description
- Since we can send the token from both clicking the token in Home page and clicking the "Send" button, we need to create `SendTokenContext` to share the global state of `selectedToken` and `step`.
  - After integrating the Send flow, we could remove `TokenSendModal`.
- Extract `tokenItem` and `tokenList` components

# Screenshots
### clicking the token in Home page

https://github.com/user-attachments/assets/2592d35a-ac9d-4b44-b890-b945554c893a


### clicking the "Send" button

https://github.com/user-attachments/assets/ab1e81bd-a70c-4017-8ca1-7fe55488d197

