### PR TITLE
Propagate error to app

### DIFF
--- a/app/page/review/transaction.tsx
+++ b/app/page/review/transaction.tsx
@@ -141,6 +141,7 @@ function UserOperationConfirmation(props: {
         setIsSigning(false)
         console.log("signErr", signErr)
         setToast("Verify passkey failed.", "failed")
+        return
       }
 
       const userOpHash = await provider.send(

--- a/background/messages/JsonRpcRequest.ts
+++ b/background/messages/JsonRpcRequest.ts
@@ -3,7 +3,7 @@ import { format } from "util"
 import { type PlasmoMessaging } from "@plasmohq/messaging"
 
 import { getWaalletBackgroundProvider } from "~background/provider"
-import { JsonRpcProviderError } from "~packages/rpc/json/error"
+import { JsonRpcError } from "~packages/rpc/json/error"
 import { WaalletMessage } from "~packages/waallet/message"
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
@@ -20,7 +20,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
     )
     res.send(result)
   } catch (error) {
-    if (error instanceof JsonRpcProviderError) {
+    if (error instanceof JsonRpcError) {
       console.log(
         `[background][message][${WaalletMessage.JsonRpcRequest}][JsonRpcProviderError]`,
         error.unwrap()

--- a/background/messages/JsonRpcRequest.ts
+++ b/background/messages/JsonRpcRequest.ts
@@ -32,7 +32,16 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
       "[background][message][JsonRpcRequest][InternalError]",
       format(error)
     )
-    res.send(error)
+    const internalError = new JsonRpcError({
+      jsonrpc: "2.0",
+      id: 0,
+      error: {
+        code: -32603,
+        message: "Internal error",
+        data: error.message
+      }
+    })
+    res.send(internalError.unwrap())
   }
 }
 

--- a/background/messages/JsonRpcRequest.ts
+++ b/background/messages/JsonRpcRequest.ts
@@ -3,7 +3,7 @@ import { format } from "util"
 import { type PlasmoMessaging } from "@plasmohq/messaging"
 
 import { getWaalletBackgroundProvider } from "~background/provider"
-import { JsonRpcError } from "~packages/rpc/json/error"
+import { ProviderRpcError } from "~packages/rpc/json/error"
 import { WaalletMessage } from "~packages/waallet/message"
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
@@ -20,25 +20,23 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
     )
     res.send(result)
   } catch (error) {
-    if (error instanceof JsonRpcError) {
+    if (error instanceof ProviderRpcError) {
       console.log(
         `[background][message][${WaalletMessage.JsonRpcRequest}][JsonRpcProviderError]`,
         error.unwrap()
       )
-      res.send(error.unwrap())
+      res.send(error)
       return
     }
     console.log(
       "[background][message][JsonRpcRequest][InternalError]",
       format(error)
     )
-    const internalError = new JsonRpcError({
+    const internalError = new ProviderRpcError({
       jsonrpc: "2.0",
       id: 0,
-      error: {
-        code: -32603,
-        message: error.message
-      }
+      code: -32603,
+      message: error.message
     })
     res.send(internalError.unwrap())
   }

--- a/background/messages/JsonRpcRequest.ts
+++ b/background/messages/JsonRpcRequest.ts
@@ -33,8 +33,6 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
       format(error)
     )
     const internalError = new ProviderRpcError({
-      jsonrpc: "2.0",
-      id: 0,
       code: -32603,
       message: error.message
     })

--- a/background/messages/JsonRpcRequest.ts
+++ b/background/messages/JsonRpcRequest.ts
@@ -26,6 +26,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
         error.unwrap()
       )
       res.send(error.unwrap())
+      return
     }
     console.log(
       "[background][message][JsonRpcRequest][InternalError]",

--- a/background/messages/JsonRpcRequest.ts
+++ b/background/messages/JsonRpcRequest.ts
@@ -1,6 +1,9 @@
+import { format } from "util"
+
 import { type PlasmoMessaging } from "@plasmohq/messaging"
 
 import { getWaalletBackgroundProvider } from "~background/provider"
+import { JsonRpcProviderError } from "~packages/rpc/json/error"
 import { WaalletMessage } from "~packages/waallet/message"
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
@@ -8,13 +11,28 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
     `[background][message][${WaalletMessage.JsonRpcRequest}][request]`,
     req
   )
-  const provider = getWaalletBackgroundProvider()
-  const result = await provider.request(req.body)
-  console.log(
-    `[background][message][${WaalletMessage.JsonRpcRequest}][response]`,
-    result
-  )
-  res.send(result)
+  try {
+    const provider = getWaalletBackgroundProvider()
+    const result = await provider.request(req.body)
+    console.log(
+      `[background][message][${WaalletMessage.JsonRpcRequest}][response]`,
+      result
+    )
+    res.send(result)
+  } catch (error) {
+    if (error instanceof JsonRpcProviderError) {
+      console.log(
+        `[background][message][${WaalletMessage.JsonRpcRequest}][JsonRpcProviderError]`,
+        error.unwrap()
+      )
+      res.send(error.unwrap())
+    }
+    console.log(
+      "[background][message][JsonRpcRequest][InternalError]",
+      format(error)
+    )
+    res.send(error)
+  }
 }
 
 export default handler

--- a/background/messages/JsonRpcRequest.ts
+++ b/background/messages/JsonRpcRequest.ts
@@ -37,8 +37,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
       id: 0,
       error: {
         code: -32603,
-        message: "Internal error",
-        data: error.message
+        message: error.message
       }
     })
     res.send(internalError.unwrap())

--- a/packages/bundler/provider.ts
+++ b/packages/bundler/provider.ts
@@ -280,7 +280,7 @@ export class BundlerProvider {
         method: BundlerRpcMethod.debug_bundler_sendBundleNow
       })
     } catch (err) {
-      throw err
+      return // no op to send in debug mode,  so ignore the error
     }
   }
 }

--- a/packages/bundler/provider.ts
+++ b/packages/bundler/provider.ts
@@ -1,5 +1,4 @@
 import { Execution } from "~packages/account"
-import { JsonRpcProviderError } from "~packages/rpc/json/error"
 import address from "~packages/util/address"
 import number from "~packages/util/number"
 import type { BigNumberish, HexString, Nullable } from "~typing"

--- a/packages/rpc/json/error.ts
+++ b/packages/rpc/json/error.ts
@@ -1,35 +1,64 @@
 import type { JsonRpcResponse } from "./provider"
 
-export class JsonRpcError extends Error {
-  public readonly jsonrpc: string
-  public readonly id: number
-  public readonly error: {
-    code: number
-    message: string
-    data?: unknown
-  }
+// https://eips.ethereum.org/EIPS/eip-1193#errors
+// ProviderRpcError need to implement code, message, data
+
+export class ProviderRpcError extends Error {
+  public readonly code: number
+  public readonly message: string
+  public readonly data?: unknown
+  public readonly jsonrpc?: string
+  public readonly id?: number
 
   public static wrap(payload: JsonRpcResponse<unknown>) {
-    return new JsonRpcError(payload)
+    if (payload.error) {
+      return new ProviderRpcError({
+        jsonrpc: payload.jsonrpc,
+        id: payload.id,
+        code: payload.error.code,
+        message: payload.error.message,
+        data: payload.error.data
+      })
+    } else {
+      return new ProviderRpcError({
+        jsonrpc: payload.jsonrpc,
+        id: payload.id,
+        code: -32603,
+        message: "Internal error: no error object in response"
+      })
+    }
   }
 
-  public constructor(payload: JsonRpcResponse<unknown>) {
-    super(payload.error.message)
+  public constructor(payload: {
+    jsonrpc: string
+    id: number
+    message: string
+    code: number
+    data?: unknown
+  }) {
+    super(payload.message)
     this.name = "JsonRpcError"
-    this.jsonrpc = payload.jsonrpc
-    this.id = payload.id
-    this.error = payload.error
+    this.jsonrpc = payload.jsonrpc || "2.0"
+    this.id = payload.id ?? 0
+    this.code = payload.code
+    this.message = payload.message
+    this.data = payload.data
 
     if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, JsonRpcError)
+      Error.captureStackTrace(this, ProviderRpcError)
     }
   }
 
   public unwrap() {
+    // unwrap to JSON-RPC error object
     return {
       jsonrpc: this.jsonrpc,
       id: this.id,
-      error: this.error
+      error: {
+        code: this.code,
+        message: this.message,
+        data: this.data
+      }
     }
   }
 }

--- a/packages/rpc/json/error.ts
+++ b/packages/rpc/json/error.ts
@@ -1,0 +1,27 @@
+export class JsonRpcProviderError extends Error {
+  public readonly code: number
+  public readonly data?: unknown
+
+  public static wrap(error: { message: string; code: number; data?: unknown }) {
+    return new JsonRpcProviderError(error.message, error.code, error.data)
+  }
+
+  public constructor(message: string, code: number, data?: unknown) {
+    super(message)
+    this.name = "JsonRpcProviderError"
+    this.code = code
+    this.data = data
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, JsonRpcProviderError)
+    }
+  }
+
+  public unwrap() {
+    return {
+      message: this.message,
+      code: this.code,
+      data: this.data
+    }
+  }
+}

--- a/packages/rpc/json/error.ts
+++ b/packages/rpc/json/error.ts
@@ -7,22 +7,16 @@ export class ProviderRpcError extends Error {
   public readonly code: number
   public readonly message: string
   public readonly data?: unknown
-  public readonly jsonrpc?: string
-  public readonly id?: number
 
   public static wrap(payload: JsonRpcResponse<unknown>) {
     if (payload.error) {
       return new ProviderRpcError({
-        jsonrpc: payload.jsonrpc,
-        id: payload.id,
         code: payload.error.code,
         message: payload.error.message,
         data: payload.error.data
       })
     } else {
       return new ProviderRpcError({
-        jsonrpc: payload.jsonrpc,
-        id: payload.id,
         code: -32603,
         message: "Internal error: no error object in response"
       })
@@ -30,16 +24,12 @@ export class ProviderRpcError extends Error {
   }
 
   public constructor(payload: {
-    jsonrpc: string
-    id: number
     message: string
     code: number
     data?: unknown
   }) {
     super(payload.message)
     this.name = "JsonRpcError"
-    this.jsonrpc = payload.jsonrpc || "2.0"
-    this.id = payload.id ?? 0
     this.code = payload.code
     this.message = payload.message
     this.data = payload.data
@@ -52,8 +42,6 @@ export class ProviderRpcError extends Error {
   public unwrap() {
     // unwrap to JSON-RPC error object
     return {
-      jsonrpc: this.jsonrpc,
-      id: this.id,
       error: {
         code: this.code,
         message: this.message,

--- a/packages/rpc/json/error.ts
+++ b/packages/rpc/json/error.ts
@@ -1,9 +1,9 @@
-export class JsonRpcProviderError extends Error {
+export class JsonRpcError extends Error {
   public readonly code: number
   public readonly data?: unknown
 
   public static wrap(error: { message: string; code: number; data?: unknown }) {
-    return new JsonRpcProviderError(error.message, error.code, error.data)
+    return new JsonRpcError(error.message, error.code, error.data)
   }
 
   public constructor(message: string, code: number, data?: unknown) {
@@ -13,7 +13,7 @@ export class JsonRpcProviderError extends Error {
     this.data = data
 
     if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, JsonRpcProviderError)
+      Error.captureStackTrace(this, JsonRpcError)
     }
   }
 

--- a/packages/rpc/json/error.ts
+++ b/packages/rpc/json/error.ts
@@ -1,16 +1,24 @@
-export class JsonRpcError extends Error {
-  public readonly code: number
-  public readonly data?: unknown
+import type { JsonRpcResponse } from "./provider"
 
-  public static wrap(error: { message: string; code: number; data?: unknown }) {
-    return new JsonRpcError(error.message, error.code, error.data)
+export class JsonRpcError extends Error {
+  public readonly jsonrpc: string
+  public readonly id: number
+  public readonly error: {
+    code: number
+    message: string
+    data?: unknown
   }
 
-  public constructor(message: string, code: number, data?: unknown) {
-    super(message)
-    this.name = "JsonRpcProviderError"
-    this.code = code
-    this.data = data
+  public static wrap(payload: JsonRpcResponse<unknown>) {
+    return new JsonRpcError(payload)
+  }
+
+  public constructor(payload: JsonRpcResponse<unknown>) {
+    super(payload.error.message)
+    this.name = "JsonRpcError"
+    this.jsonrpc = payload.jsonrpc
+    this.id = payload.id
+    this.error = payload.error
 
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, JsonRpcError)
@@ -19,9 +27,9 @@ export class JsonRpcError extends Error {
 
   public unwrap() {
     return {
-      message: this.message,
-      code: this.code,
-      data: this.data
+      jsonrpc: this.jsonrpc,
+      id: this.id,
+      error: this.error
     }
   }
 }

--- a/packages/rpc/json/provider.ts
+++ b/packages/rpc/json/provider.ts
@@ -4,7 +4,7 @@ import json, { format, replacer } from "~packages/util/json"
 
 import { JsonRpcError } from "./error"
 
-type JsonRpcResponse<T extends any> = {
+export type JsonRpcResponse<T extends any> = {
   jsonrpc: "2.0"
   id: number
   result?: T
@@ -49,7 +49,7 @@ export class JsonRpcProvider {
 
       if (payload.error) {
         // 200 response but may have issues executing that request
-        throw JsonRpcError.wrap(payload.error)
+        throw JsonRpcError.wrap(payload)
       }
       console.log(
         `[JsonRpcProvider][${args.method}][response] ${format(payload)}`

--- a/packages/rpc/json/provider.ts
+++ b/packages/rpc/json/provider.ts
@@ -2,7 +2,7 @@ import fetch from "isomorphic-fetch"
 
 import json, { format, replacer } from "~packages/util/json"
 
-import { JsonRpcError } from "./error"
+import { ProviderRpcError } from "./error"
 
 export type JsonRpcResponse<T extends any> = {
   jsonrpc: "2.0"
@@ -49,7 +49,7 @@ export class JsonRpcProvider {
 
       if (payload.error) {
         // 200 response but may have issues executing that request
-        throw JsonRpcError.wrap(payload)
+        throw ProviderRpcError.wrap(payload)
       }
       console.log(
         `[JsonRpcProvider][${args.method}][response] ${format(payload)}`
@@ -57,17 +57,15 @@ export class JsonRpcProvider {
       return payload.result
     } catch (err) {
       console.log(`[JsonRpcProvider][${args.method}][error] ${format(err)}`)
-      if (err instanceof JsonRpcError) {
+      if (err instanceof ProviderRpcError) {
         throw err
       }
 
-      throw new JsonRpcError({
+      throw new ProviderRpcError({
         jsonrpc: "2.0",
         id: 0,
-        error: {
-          code: -32600,
-          message: "Invalid Request"
-        }
+        code: -32600,
+        message: "Invalid Request"
       })
     }
   }

--- a/packages/rpc/json/provider.ts
+++ b/packages/rpc/json/provider.ts
@@ -60,8 +60,17 @@ export class JsonRpcProvider {
         console.log(`[JsonRpcProvider][${args.method}][error] ${format(err)}`)
         throw err
       }
-      console.log(`[JsonRpcProvider][${args.method}][error] ${format(err)}`)
-      throw err
+      console.log(
+        `[JsonRpcProvider][${args.method}][stringify error] ${format(err)}`
+      )
+      throw new JsonRpcError({
+        jsonrpc: "2.0",
+        id: 0,
+        error: {
+          code: -32600,
+          message: "Invalid Request"
+        }
+      })
     }
   }
 }

--- a/packages/rpc/json/provider.ts
+++ b/packages/rpc/json/provider.ts
@@ -62,8 +62,6 @@ export class JsonRpcProvider {
       }
 
       throw new ProviderRpcError({
-        jsonrpc: "2.0",
-        id: 0,
         code: -32600,
         message: "Invalid Request"
       })

--- a/packages/rpc/json/provider.ts
+++ b/packages/rpc/json/provider.ts
@@ -56,13 +56,11 @@ export class JsonRpcProvider {
       )
       return payload.result
     } catch (err) {
+      console.log(`[JsonRpcProvider][${args.method}][error] ${format(err)}`)
       if (err instanceof JsonRpcError) {
-        console.log(`[JsonRpcProvider][${args.method}][error] ${format(err)}`)
         throw err
       }
-      console.log(
-        `[JsonRpcProvider][${args.method}][stringify error] ${format(err)}`
-      )
+
       throw new JsonRpcError({
         jsonrpc: "2.0",
         id: 0,

--- a/packages/rpc/json/provider.ts
+++ b/packages/rpc/json/provider.ts
@@ -2,6 +2,19 @@ import fetch from "isomorphic-fetch"
 
 import json, { format, replacer } from "~packages/util/json"
 
+import { JsonRpcProviderError } from "./error"
+
+type JsonRpcResponse<T extends any> = {
+  jsonrpc: "2.0"
+  id: number
+  result?: T
+  error?: {
+    code: number
+    message: string
+    data?: any
+  }
+}
+
 export class JsonRpcProvider {
   public constructor(public readonly rpcUrl: string) {}
 
@@ -9,36 +22,46 @@ export class JsonRpcProvider {
     method: string
     params?: any[]
   }): Promise<T> {
-    const body = json.stringify(
-      {
-        jsonrpc: "2.0",
-        id: 0,
-        ...args
-      },
-      (k, v) => {
-        if (k === "id") {
-          return v
+    try {
+      const body = json.stringify(
+        {
+          jsonrpc: "2.0",
+          id: 0,
+          ...args
+        },
+        (k, v) => {
+          if (k === "id") {
+            return v
+          }
+          return replacer.numberToHex(k, v)
         }
-        return replacer.numberToHex(k, v)
+      )
+      console.log(`[JsonRpcProvider][${args.method}][request] ${body}`)
+
+      const res = await fetch(this.rpcUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body
+      })
+      const payload: JsonRpcResponse<T> = await res.json()
+
+      if (payload.error) {
+        // 200 response but may have issues executing that request
+        throw JsonRpcProviderError.wrap(payload.error)
       }
-    )
-    console.log(`[JsonRpcProvider][${args.method}][request] ${body}`)
-    const res = await fetch(this.rpcUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body
-    })
-    const data = await res.json()
-    // TODO: Should handle error
-    // {
-    //     jsonrpc: '2.0',
-    //     error: { code: -32521, message: "user operation's call reverted: 0x" },
-    //     id: 0
-    // }
-    console.log(`[JsonRpcProvider][${args.method}][response] ${format(data)}`)
-    // TODO: Transform error to error instance
-    return data.result as T
+      console.log(
+        `[JsonRpcProvider][${args.method}][response] ${format(payload)}`
+      )
+      return payload.result
+    } catch (err) {
+      if (err instanceof JsonRpcProviderError) {
+        console.log(`[JsonRpcProvider][${args.method}][error] ${format(err)}`)
+        throw err
+      }
+      console.log(`[JsonRpcProvider][${args.method}][error] ${format(err)}`)
+      throw err
+    }
   }
 }

--- a/packages/rpc/json/provider.ts
+++ b/packages/rpc/json/provider.ts
@@ -2,7 +2,7 @@ import fetch from "isomorphic-fetch"
 
 import json, { format, replacer } from "~packages/util/json"
 
-import { JsonRpcProviderError } from "./error"
+import { JsonRpcError } from "./error"
 
 type JsonRpcResponse<T extends any> = {
   jsonrpc: "2.0"
@@ -49,14 +49,14 @@ export class JsonRpcProvider {
 
       if (payload.error) {
         // 200 response but may have issues executing that request
-        throw JsonRpcProviderError.wrap(payload.error)
+        throw JsonRpcError.wrap(payload.error)
       }
       console.log(
         `[JsonRpcProvider][${args.method}][response] ${format(payload)}`
       )
       return payload.result
     } catch (err) {
-      if (err instanceof JsonRpcProviderError) {
+      if (err instanceof JsonRpcError) {
         console.log(`[JsonRpcProvider][${args.method}][error] ${format(err)}`)
         throw err
       }

--- a/packages/waallet/background/provider.ts
+++ b/packages/waallet/background/provider.ts
@@ -41,34 +41,30 @@ export class WaalletBackgroundProvider {
 
   public async request<T>(args: WaalletRequestArguments): Promise<T> {
     console.log(args)
-    try {
-      const { node, bundler } = this.networkManager.getActive()
-      switch (args.method) {
-        case WaalletRpcMethod.eth_accounts:
-        case WaalletRpcMethod.eth_requestAccounts:
-          const { account } = await this.accountManager.getActive()
-          return [await account.getAddress()] as T
-        case WaalletRpcMethod.eth_chainId:
-          return number.toHex(await bundler.getChainId()) as T
-        case WaalletRpcMethod.eth_estimateGas:
-          return this.handleEstimateGas(args.params) as T
-        case WaalletRpcMethod.eth_estimateUserOperationGas:
-          return this.handleEstimateUserOperationGas(args.params) as T
-        case WaalletRpcMethod.eth_sendTransaction:
-          return this.handleSendTransaction(args.params) as T
-        case WaalletRpcMethod.eth_sendUserOperation:
-          return this.handleSendUserOperation(args.params) as T
-        case WaalletRpcMethod.custom_estimateGasPrice:
-          return this.handleEstimateGasPrice() as T
-        // TODO: Need split the RequestArgs to NodeRequestArgs | BundlerRequestArgs
-        default:
-          if (args.method in BundlerRpcMethod) {
-            return new JsonRpcProvider(bundler.url).send(args)
-          }
-          return new JsonRpcProvider(node.url).send(args)
-      }
-    } catch (err) {
-      throw err
+    const { node, bundler } = this.networkManager.getActive()
+    switch (args.method) {
+      case WaalletRpcMethod.eth_accounts:
+      case WaalletRpcMethod.eth_requestAccounts:
+        const { account } = await this.accountManager.getActive()
+        return [await account.getAddress()] as T
+      case WaalletRpcMethod.eth_chainId:
+        return number.toHex(await bundler.getChainId()) as T
+      case WaalletRpcMethod.eth_estimateGas:
+        return this.handleEstimateGas(args.params) as T
+      case WaalletRpcMethod.eth_estimateUserOperationGas:
+        return this.handleEstimateUserOperationGas(args.params) as T
+      case WaalletRpcMethod.eth_sendTransaction:
+        return this.handleSendTransaction(args.params) as T
+      case WaalletRpcMethod.eth_sendUserOperation:
+        return this.handleSendUserOperation(args.params) as T
+      case WaalletRpcMethod.custom_estimateGasPrice:
+        return this.handleEstimateGasPrice() as T
+      // TODO: Need split the RequestArgs to NodeRequestArgs | BundlerRequestArgs
+      default:
+        if (args.method in BundlerRpcMethod) {
+          return new JsonRpcProvider(bundler.url).send(args)
+        }
+        return new JsonRpcProvider(node.url).send(args)
     }
   }
 
@@ -80,48 +76,40 @@ export class WaalletBackgroundProvider {
       // TODO: When `to` is empty, it should estimate gas for contract creation
       return
     }
-    try {
-      const { account } = await this.accountManager.getActive()
-      if (tx.from && !address.isEqual(tx.from, await account.getAddress())) {
-        throw new Error("Address `from` doesn't match connected account")
-      }
-      const { bundler } = this.networkManager.getActive()
-      const entryPoint = await account.getEntryPoint()
-      if (!bundler.isSupportedEntryPoint(entryPoint)) {
-        throw new Error(`Unsupported EntryPoint ${entryPoint}`)
-      }
-      const userOp = bundler.deriveUserOperation(
-        await account.buildExecution({
-          to: tx.to,
-          value: tx.value,
-          data: tx.data
-        }),
-        entryPoint
-      )
-      if (tx.gas) {
-        userOp.setGasLimit({ callGasLimit: tx.gas })
-      }
-      const { callGasLimit } = await bundler.estimateUserOperationGas(
-        userOp,
-        entryPoint
-      )
-      return number.toHex(callGasLimit)
-    } catch (err) {
-      throw err
+    const { account } = await this.accountManager.getActive()
+    if (tx.from && !address.isEqual(tx.from, await account.getAddress())) {
+      throw new Error("Address `from` doesn't match connected account")
     }
+    const { bundler } = this.networkManager.getActive()
+    const entryPoint = await account.getEntryPoint()
+    if (!bundler.isSupportedEntryPoint(entryPoint)) {
+      throw new Error(`Unsupported EntryPoint ${entryPoint}`)
+    }
+    const userOp = bundler.deriveUserOperation(
+      await account.buildExecution({
+        to: tx.to,
+        value: tx.value,
+        data: tx.data
+      }),
+      entryPoint
+    )
+    if (tx.gas) {
+      userOp.setGasLimit({ callGasLimit: tx.gas })
+    }
+    const { callGasLimit } = await bundler.estimateUserOperationGas(
+      userOp,
+      entryPoint
+    )
+    return number.toHex(callGasLimit)
   }
 
   private async handleEstimateGasPrice() {
     const { node, bundler } = this.networkManager.getActive()
     const gasPriceEstimator = new GasPriceEstimator(node, bundler)
-    try {
-      const gasPrice = await gasPriceEstimator.estimate()
-      return {
-        maxFeePerGas: number.toHex(gasPrice.maxFeePerGas),
-        maxPriorityFeePerGas: number.toHex(gasPrice.maxPriorityFeePerGas)
-      }
-    } catch (err) {
-      throw err
+    const gasPrice = await gasPriceEstimator.estimate()
+    return {
+      maxFeePerGas: number.toHex(gasPrice.maxFeePerGas),
+      maxPriorityFeePerGas: number.toHex(gasPrice.maxPriorityFeePerGas)
     }
   }
 
@@ -135,24 +123,20 @@ export class WaalletBackgroundProvider {
   }> {
     const [userOp, entryPoint] = params
     const { bundler } = this.networkManager.getActive()
-    try {
-      if (!bundler.isSupportedEntryPoint(entryPoint)) {
-        throw new Error(`Unsupported EntryPoint ${entryPoint}`)
-      }
-      const data = await bundler.estimateUserOperationGas(
-        bundler.deriveUserOperation(userOp, entryPoint),
-        entryPoint
+    if (!bundler.isSupportedEntryPoint(entryPoint)) {
+      throw new Error(`Unsupported EntryPoint ${entryPoint}`)
+    }
+    const data = await bundler.estimateUserOperationGas(
+      bundler.deriveUserOperation(userOp, entryPoint),
+      entryPoint
+    )
+    return {
+      preVerificationGas: number.toHex(data.preVerificationGas),
+      verificationGasLimit: number.toHex(data.verificationGasLimit),
+      callGasLimit: number.toHex(data.callGasLimit),
+      paymasterVerificationGasLimit: number.toHex(
+        data.paymasterVerificationGasLimit ?? 0n
       )
-      return {
-        preVerificationGas: number.toHex(data.preVerificationGas),
-        verificationGasLimit: number.toHex(data.verificationGasLimit),
-        callGasLimit: number.toHex(data.callGasLimit),
-        paymasterVerificationGasLimit: number.toHex(
-          data.paymasterVerificationGasLimit ?? 0n
-        )
-      }
-    } catch (err) {
-      throw err
     }
   }
 
@@ -167,32 +151,28 @@ export class WaalletBackgroundProvider {
     }
 
     const { id: networkId, bundler } = this.networkManager.getActive()
-    try {
-      const { id: accountId, account } = await this.accountManager.getActive()
-      if (tx.from && !address.isEqual(tx.from, await account.getAddress())) {
-        throw new Error("Address `from` doesn't match connected account")
-      }
-
-      const entryPoint = await account.getEntryPoint()
-      if (!bundler.isSupportedEntryPoint(entryPoint)) {
-        throw new Error(`Unsupported EntryPoint ${entryPoint}`)
-      }
-
-      const txId = await this.transactionPool.send({
-        tx: new Transaction({
-          ...tx,
-          to: tx.to,
-          gasLimit: tx.gas
-        }),
-        senderId: accountId,
-        networkId
-      })
-      const transactionHash = await this.transactionPool.wait(txId)
-
-      return transactionHash
-    } catch (err) {
-      throw err
+    const { id: accountId, account } = await this.accountManager.getActive()
+    if (tx.from && !address.isEqual(tx.from, await account.getAddress())) {
+      throw new Error("Address `from` doesn't match connected account")
     }
+
+    const entryPoint = await account.getEntryPoint()
+    if (!bundler.isSupportedEntryPoint(entryPoint)) {
+      throw new Error(`Unsupported EntryPoint ${entryPoint}`)
+    }
+
+    const txId = await this.transactionPool.send({
+      tx: new Transaction({
+        ...tx,
+        to: tx.to,
+        gasLimit: tx.gas
+      }),
+      senderId: accountId,
+      networkId
+    })
+    const transactionHash = await this.transactionPool.wait(txId)
+
+    return transactionHash
   }
 
   private async handleSendUserOperation(
@@ -200,13 +180,9 @@ export class WaalletBackgroundProvider {
   ): Promise<HexString> {
     const [userOp, entryPoint] = params
     const { bundler } = this.networkManager.getActive()
-    try {
-      return bundler.sendUserOperation(
-        bundler.deriveUserOperation(userOp, entryPoint),
-        entryPoint
-      )
-    } catch (err) {
-      throw err
-    }
+    return bundler.sendUserOperation(
+      bundler.deriveUserOperation(userOp, entryPoint),
+      entryPoint
+    )
   }
 }

--- a/packages/waallet/content/provider.ts
+++ b/packages/waallet/content/provider.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events"
 
 import { type BackgroundMessenger } from "~packages/messenger/background"
+import { ProviderRpcError } from "~packages/rpc/json/error"
 import type { JsonRpcResponse } from "~packages/rpc/json/provider"
 import { format } from "~packages/util/json"
 import type { WebAuthnCreation, WebAuthnRequest } from "~packages/webAuthn"
@@ -8,10 +9,6 @@ import type { WebAuthnCreation, WebAuthnRequest } from "~packages/webAuthn"
 import { WaalletMessage } from "../message"
 import { type WaalletRequestArguments } from "../rpc"
 
-type WalletProviderError = Error & {
-  code?: number
-  data?: unknown
-}
 export class WaalletContentProvider extends EventEmitter {
   public constructor(private backgroundMessenger: BackgroundMessenger) {
     super()
@@ -23,12 +20,8 @@ export class WaalletContentProvider extends EventEmitter {
       body: args
     })
 
-    // https://github.com/ethers-io/ethers.js/blob/72c2182d01afa855d131e82635dca3da063cfb31/src.ts/providers/provider-browser.ts#L69-L85
     if (res.error) {
-      const error: WalletProviderError = new Error(res.error.message)
-      error.code = res.error.code
-      error.data = res.error.data
-      throw error
+      throw ProviderRpcError.wrap(res)
     }
     return res as T
   }


### PR DESCRIPTION
This PR is trying to propagate the errors from background by:
- create a class `ProviderRpcError` to conform with [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193#errors)
  ```
  interface ProviderRpcError extends Error {
    message: string;
    code: number;
    data?: unknown;
  }
  ```
  - `wrap`: convert JSON-RPC response to `ProviderRpcError`
  - `unwrap`: convert `ProviderRpcError` to JSON-RPC response
  
- Since plasmo message only send plaint text, our app provider(ethers) will not break and keep sending error to provider.
  - To make our app provider notice the error, we [convert plain text err res into an error object](https://github.com/pilagod/waallet-extension/pull/179/commits/bb2252e08b4fd5c2445206e3a0fc2b5d08113cd0) in waallet/content/provider.ts 