### PR TITLE
Unwrap error and handler error for executed reverted from bundler

### DIFF
--- a/app/page/review/transaction.tsx
+++ b/app/page/review/transaction.tsx
@@ -213,19 +213,6 @@ function UserOperationConfirmation(props: {
   }, [tx.id])
 
   useEffect(() => {
-    async function estimateUserOp() {
-      setUserOpEstimating(true)
-      await estimateGas(userOp)
-      setUserOp(userOp)
-      setUserOpEstimating(false)
-    }
-    if (!userOp) {
-      return
-    }
-    estimateUserOp()
-  }, [])
-
-  useEffect(() => {
     async function calculatePayment() {
       setPaymentCalculating(true)
       setPayment({

--- a/app/page/review/transaction.tsx
+++ b/app/page/review/transaction.tsx
@@ -199,7 +199,7 @@ function UserOperationConfirmation(props: {
     } catch (e) {
       console.error(e)
       if (e.error?.code === -32521) {
-        throw new Error("Execution Reverted from bundler")
+        throw new Error("Estimation reverted from bundler")
       }
       throw e
     }

--- a/background/messages/JsonRpcRequest.ts
+++ b/background/messages/JsonRpcRequest.ts
@@ -25,7 +25,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
         `[background][message][${WaalletMessage.JsonRpcRequest}][JsonRpcProviderError]`,
         error.unwrap()
       )
-      res.send(error)
+      res.send(error.unwrap())
       return
     }
     console.log(


### PR DESCRIPTION
# Description
- Stacked on #189 
- To make content script know [if the response is an error response](https://github.com/pilagod/waallet-extension/blob/main/packages/waallet/content/provider.ts#L23), we need to send JSON-RPC format res(unwrap `ProviderRpcError`) from background.
- `estimateUserOp` is not needed because useEffect only run on the first time and `userOp` is null at the moment.
- catch the error from `estimateUserOperationGas`

https://github.com/user-attachments/assets/c2291535-c12b-4f85-9beb-aba952895177

