### PR TITLE
Add Input name to support auto-complete

### DIFF
--- a/app/component/input.tsx
+++ b/app/component/input.tsx
@@ -2,7 +2,7 @@ import { type ChangeEvent } from "react"
 
 export function Input(props: {
   value: string
-  name: string
+  name?: string
   label?: string
   disabled?: boolean
   placeholder?: string

--- a/app/component/input.tsx
+++ b/app/component/input.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent } from "react"
 
 export function Input(props: {
   value: string
+  name: string
   label?: string
   disabled?: boolean
   placeholder?: string
@@ -13,6 +14,7 @@ export function Input(props: {
       {props.label && <div className="mb-[8px] text-[16px]">{props.label}</div>}
       <input
         type="text"
+        name={props.name} // To improve auto-complete support
         value={props.value}
         onChange={(e: ChangeEvent<HTMLInputElement>) =>
           props.onValueChanged(e.target.value)

--- a/app/page/account/create/index.tsx
+++ b/app/page/account/create/index.tsx
@@ -67,6 +67,7 @@ export function AccountCreate() {
       <section className="h-[373px] pt-[24px]">
         <Input
           label="Set account name"
+          name="accountName"
           value={accountName}
           placeholder="Enter account name"
           onValueChanged={onAccountNameChanged}

--- a/app/page/importToken/index.tsx
+++ b/app/page/importToken/index.tsx
@@ -93,12 +93,7 @@ export function ImportToken() {
         {/* Token Symbol */}
         {tokenSymbol && (
           <div className="mt-[16px]">
-            <Input
-              label="Symbol"
-              name="tokenSymbol"
-              value={tokenSymbol}
-              disabled={true}
-            />
+            <Input label="Symbol" value={tokenSymbol} disabled={true} />
           </div>
         )}
 
@@ -107,7 +102,6 @@ export function ImportToken() {
           <div className="mt-[16px]">
             <Input
               label="Decimals"
-              name="tokenDecimals"
               value={tokenDecimals.toString()}
               disabled={true}
             />

--- a/app/page/importToken/index.tsx
+++ b/app/page/importToken/index.tsx
@@ -82,6 +82,7 @@ export function ImportToken() {
         <div>
           <Input
             label="Contract Address"
+            name="tokenAddress"
             value={tokenAddress}
             onValueChanged={onTokenAddressChanged}
             placeholder="Enter contract address"
@@ -92,7 +93,12 @@ export function ImportToken() {
         {/* Token Symbol */}
         {tokenSymbol && (
           <div className="mt-[16px]">
-            <Input label="Symbol" value={tokenSymbol} disabled={true} />
+            <Input
+              label="Symbol"
+              name="tokenSymbol"
+              value={tokenSymbol}
+              disabled={true}
+            />
           </div>
         )}
 
@@ -101,6 +107,7 @@ export function ImportToken() {
           <div className="mt-[16px]">
             <Input
               label="Decimals"
+              name="tokenDecimals"
               value={tokenDecimals.toString()}
               disabled={true}
             />


### PR DESCRIPTION
Given the `name` of the `Input` component for auto-complete enhances user experience.

<img width="399" alt="截圖 2024-07-30 下午3 20 01" src="https://github.com/user-attachments/assets/91208485-6acf-4903-9954-d49720063f52">
