### PR TITLE
Refine resolve request flow

### DIFF
--- a/app/hook/storage.ts
+++ b/app/hook/storage.ts
@@ -52,9 +52,9 @@ export const useTransactionLogs = (accountId: string) => {
   })
 }
 
-export const usePendingRequests = () => {
+export const useRequests = () => {
   return useStorage(({ state }) => {
-    return Object.values(state.pendingRequest)
+    return Object.values(state.request)
   })
 }
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -63,10 +63,10 @@ function PageRouter() {
     window.scrollTo(0, 0)
   }, [location])
 
-  const hasPendingRequests = useStorage(
-    useShallow(({ state }) => Object.keys(state.pendingRequest).length > 0)
+  const hasRequests = useStorage(
+    useShallow(({ state }) => Object.keys(state.request).length > 0)
   )
-  if (hasPendingRequests && !location.startsWith(Path.Review)) {
+  if (hasRequests && !location.startsWith(Path.Review)) {
     navigate(Path.Review)
     return
   }

--- a/app/page/review/eip712.tsx
+++ b/app/page/review/eip712.tsx
@@ -17,10 +17,10 @@ export function Eip712Confirmation(props: {
 }) {
   const { request, account } = props
 
-  const { cancelEip712Request, resolveEip712Request } = useAction()
+  const { rejectEip712Request, resolveEip712Request } = useAction()
 
   const cancel = async () => {
-    await cancelEip712Request(request.id)
+    await rejectEip712Request(request.id)
   }
   const sign = async () => {
     const signature = await account.actor.sign(eip712Hash(request))

--- a/app/page/review/index.tsx
+++ b/app/page/review/index.tsx
@@ -44,7 +44,7 @@ export function Review() {
     <ProfileSwitcher
       accountId={request.accountId}
       networkId={request.networkId}>
-      <RequestConfirmation request={requests[0]} />
+      <RequestConfirmation request={request} />
     </ProfileSwitcher>
   )
 }

--- a/app/page/review/index.tsx
+++ b/app/page/review/index.tsx
@@ -5,7 +5,7 @@ import { useHashLocation } from "wouter/use-hash-location"
 import { ProviderContext } from "~app/context/provider"
 import { useAccount, useNetwork } from "~app/hook/storage"
 import { Path } from "~app/path"
-import { useAction, usePendingRequests } from "~app/storage"
+import { useAction, useRequests } from "~app/storage"
 import type { Account } from "~packages/account"
 import { AccountStorageManager } from "~storage/local/manager"
 import { RequestType, type Request } from "~storage/local/state"
@@ -15,7 +15,7 @@ import { TransactionConfirmation } from "./transaction"
 
 export function Review() {
   const [, navigate] = useHashLocation()
-  const pendingRequests = usePendingRequests()
+  const requests = useRequests()
 
   useEffect(() => {
     async function redirect() {
@@ -29,22 +29,22 @@ export function Review() {
         navigate(Path.Home)
       }
     }
-    if (pendingRequests.length === 0) {
+    if (requests.length === 0) {
       redirect()
     }
-  }, [pendingRequests.length])
+  }, [requests.length])
 
-  if (pendingRequests.length === 0) {
+  if (requests.length === 0) {
     return
   }
 
-  const [request] = pendingRequests
+  const [request] = requests
 
   return (
     <ProfileSwitcher
       accountId={request.accountId}
       networkId={request.networkId}>
-      <PendingRequestConfirmation request={pendingRequests[0]} />
+      <RequestConfirmation request={requests[0]} />
     </ProfileSwitcher>
   )
 }
@@ -74,7 +74,7 @@ function ProfileSwitcher(props: {
   return children
 }
 
-function PendingRequestConfirmation(props: { request: Request }) {
+function RequestConfirmation(props: { request: Request }) {
   const { request } = props
 
   const { provider } = useContext(ProviderContext)

--- a/app/page/review/transaction.tsx
+++ b/app/page/review/transaction.tsx
@@ -54,9 +54,9 @@ export function TransactionConfirmation(props: {
   const paymentOption = paymentOptions[0]
 
   const {
-    getERC4337TransactionType,
-    markERC4337TransactionSent,
-    markERC4337TransactionRejected
+    getErc4337TransactionType,
+    markErc4337TransactionSent,
+    markErc4337TransactionRejected
   } = useAction()
 
   const isContract = tx.data !== "0x"
@@ -110,7 +110,7 @@ export function TransactionConfirmation(props: {
       }
       // TODO: Wrong nonce problem when confirming consecutive pending tx
       try {
-        await markERC4337TransactionSent(tx.id, {
+        await markErc4337TransactionSent(tx.id, {
           entryPoint,
           userOp,
           userOpHash
@@ -131,7 +131,7 @@ export function TransactionConfirmation(props: {
   const rejectUserOperation = async () => {
     setUserOpResolving(true)
     try {
-      await markERC4337TransactionRejected(tx.id, {
+      await markErc4337TransactionRejected(tx.id, {
         entryPoint: await account.actor.getEntryPoint(),
         userOp
       })
@@ -174,13 +174,13 @@ export function TransactionConfirmation(props: {
   useEffect(() => {
     async function setupUserOp() {
       setUserOp(null)
-      const transactionType = getERC4337TransactionType(
+      const transactionType = getErc4337TransactionType(
         tx.networkId,
         await account.actor.getEntryPoint()
       )
       const execution = await account.actor.buildExecution(tx)
       const userOp =
-        transactionType === TransactionType.ERC4337V0_6
+        transactionType === TransactionType.Erc4337V0_6
           ? UserOperationV0_6.wrap(execution)
           : UserOperationV0_7.wrap(execution)
       try {

--- a/app/page/review/transaction.tsx
+++ b/app/page/review/transaction.tsx
@@ -108,7 +108,7 @@ export function TransactionConfirmation(props: {
       if (!userOpHash) {
         throw new Error("Fail to send user operation")
       }
-      // TODO: Wrong nonce problem when confirming consecutive pending tx
+      // TODO: Wrong nonce problem when confirming consecutive tx requests
       try {
         await markErc4337TransactionSent(tx.id, {
           entryPoint,

--- a/app/storage/index.ts
+++ b/app/storage/index.ts
@@ -9,17 +9,14 @@ import { StorageMessenger } from "./messenger"
 import { background, type BackgroundStorage } from "./middleware/background"
 import { createAccountSlice, type AccountSlice } from "./slice/account"
 import { createNetworkSlice, type NetworkSlice } from "./slice/network"
+import { createRequestSlice, type RequestSlice } from "./slice/request"
 import { createStateSlice, type StateSlice } from "./slice/state"
-import {
-  createTransactionSlice,
-  type TransactionSlice
-} from "./slice/transaction"
 
 interface Storage
   extends StateSlice,
     AccountSlice,
     NetworkSlice,
-    TransactionSlice {}
+    RequestSlice {}
 
 class StorageSyncer implements BackgroundStorage<Storage> {
   private patchesInSync: Record<string, PromiseWithResolvers<void>> = {}
@@ -81,7 +78,7 @@ export const useStorage = create<Storage>()(
       ...createStateSlice(...actions),
       ...createAccountSlice(...actions),
       ...createNetworkSlice(...actions),
-      ...createTransactionSlice(...actions)
+      ...createRequestSlice(...actions)
     }),
     new StorageSyncer(storageMessenger)
   )

--- a/app/storage/slice/request.ts
+++ b/app/storage/slice/request.ts
@@ -11,8 +11,7 @@ import type { HexString } from "~typing"
 import type { BackgroundStateCreator } from "../middleware/background"
 import type { StateSlice } from "./state"
 
-// TODO: Rename to request slice
-export interface TransactionSlice {
+export interface RequestSlice {
   /* Profile */
 
   switchProfile: (profile: {
@@ -51,9 +50,9 @@ export interface TransactionSlice {
   resolveEip712Request(requestId: string, signature: HexString): Promise<void>
 }
 
-export const createTransactionSlice: BackgroundStateCreator<
-  StateSlice & TransactionSlice,
-  TransactionSlice
+export const createRequestSlice: BackgroundStateCreator<
+  StateSlice & RequestSlice,
+  RequestSlice
 > = (set, get) => ({
   /* Profile */
 

--- a/app/storage/slice/state.ts
+++ b/app/storage/slice/state.ts
@@ -6,6 +6,6 @@ export interface StateSlice {
   state: State
 }
 
-export const createStateSlice: BackgroundStateCreator<StateSlice> = (set) => ({
+export const createStateSlice: BackgroundStateCreator<StateSlice> = (_) => ({
   state: null
 })

--- a/app/storage/slice/transaction.ts
+++ b/app/storage/slice/transaction.ts
@@ -46,7 +46,7 @@ export interface TransactionSlice {
 
   /* EIP-712 */
 
-  cancelEip712Request(requestId: string): Promise<void>
+  rejectEip712Request(requestId: string): Promise<void>
 
   resolveEip712Request(requestId: string, signature: HexString): Promise<void>
 }
@@ -122,19 +122,15 @@ export const createTransactionSlice: BackgroundStateCreator<
 
   /* EIP-712 */
 
-  cancelEip712Request: async (requestId: string) => {
+  rejectEip712Request: async (requestId: string) => {
     await set(({ state }) => {
-      const stateActor = new StateActor(state)
-      const request = stateActor.getEip712Request(requestId)
-      delete state.request[request.id]
+      new StateActor(state).rejectEip712Request(requestId)
     })
   },
 
   resolveEip712Request: async (requestId: string, signature: HexString) => {
     await set(({ state }) => {
-      const stateActor = new StateActor(state)
-      const request = stateActor.getEip712Request(requestId)
-      request.signature = signature
+      new StateActor(state).resolveEip712Request(requestId, signature)
     })
   }
 })

--- a/app/storage/slice/transaction.ts
+++ b/app/storage/slice/transaction.ts
@@ -126,7 +126,7 @@ export const createTransactionSlice: BackgroundStateCreator<
     await set(({ state }) => {
       const stateActor = new StateActor(state)
       const request = stateActor.getEip712Request(requestId)
-      delete state.pendingRequest[request.id]
+      delete state.request[request.id]
     })
   },
 

--- a/background/index.ts
+++ b/background/index.ts
@@ -11,8 +11,8 @@ import {
 } from "~storage/local/manager"
 import {
   TransactionStatus,
-  type ERC4337TransactionReverted,
-  type ERC4337TransactionSucceeded,
+  type Erc4337TransactionReverted,
+  type Erc4337TransactionSucceeded,
   type TransactionLog
 } from "~storage/local/state"
 import { getSessionStorage } from "~storage/session"
@@ -120,7 +120,7 @@ async function main() {
       }
 
       if (userOpReceipt.success) {
-        const txSucceeded: ERC4337TransactionSucceeded = {
+        const txSucceeded: Erc4337TransactionSucceeded = {
           ...txLog,
           status: TransactionStatus.Succeeded,
           receipt: {
@@ -138,7 +138,7 @@ async function main() {
       }
 
       if (!userOpReceipt.success) {
-        const txReverted: ERC4337TransactionReverted = {
+        const txReverted: Erc4337TransactionReverted = {
           ...txLog,
           status: TransactionStatus.Reverted,
           receipt: {

--- a/storage/local/actor.ts
+++ b/storage/local/actor.ts
@@ -1,4 +1,16 @@
-import { RequestType, type State } from "./state"
+import address from "~packages/util/address"
+import type { HexString } from "~typing"
+
+import {
+  RequestType,
+  TransactionType,
+  type Erc4337TransactionRejected,
+  type Erc4337TransactionSent,
+  type Request,
+  type RequestLog,
+  type RequestLogMeta,
+  type State
+} from "./state"
 
 /**
  * @dev StateActor mutates the state in-place, which can work with zustand and immer seamlessly.
@@ -20,5 +32,43 @@ export class StateActor {
       throw new Error(`EIP-712 request ${request.id} not found`)
     }
     return request
+  }
+
+  public getErc4337TransactionType(networkId: string, entryPoint: HexString) {
+    const network = this.state.network[networkId]
+    if (address.isEqual(entryPoint, network.entryPoint["v0.6"])) {
+      return TransactionType.Erc4337V0_6
+    }
+    return TransactionType.Erc4337V0_7
+  }
+
+  public resolveErc4337TransactionRequest<
+    T extends Erc4337TransactionSent | Erc4337TransactionRejected
+  >(requestId: string, data: Omit<T, keyof RequestLogMeta<{}> | "type">) {
+    const request = this.getTransactionRequest(requestId)
+    const log = this.createRequestLog(request, {
+      status: this.getErc4337TransactionType(
+        request.networkId,
+        data.detail.entryPoint
+      ),
+      ...data
+    })
+    // TODO: Do not put rejected log into account
+    this.state.account[log.accountId].transactionLog[log.id] = log
+    delete this.state.pendingRequest[log.id]
+  }
+
+  public createRequestLog<T extends RequestLog>(
+    request: Request,
+    data: Omit<T, keyof RequestLogMeta<{}>>
+  ): T {
+    return {
+      id: request.id,
+      createdAt: request.createdAt,
+      updatedAt: new Date().getTime(),
+      accountId: request.accountId,
+      networkId: request.networkId,
+      ...data
+    } as T
   }
 }

--- a/storage/local/actor.ts
+++ b/storage/local/actor.ts
@@ -79,9 +79,9 @@ export class StateActor {
     T extends Erc4337TransactionSucceeded | Erc4337TransactionReverted
   >(requestId: string, data: Omit<T, keyof Erc4337TransactionLogMeta>) {
     const log = this.getTransactionLog(requestId)
-    const next = { ...log, ...data }
-    this.state.account[log.accountId].transactionLog[log.id] = next
-    this.state.requestLog[log.id] = next
+    const logTransitted = { ...log, ...data }
+    this.state.account[log.accountId].transactionLog[log.id] = logTransitted
+    this.state.requestLog[log.id] = logTransitted
   }
 
   /* EIP-712 Request */

--- a/storage/local/index.ts
+++ b/storage/local/index.ts
@@ -92,7 +92,8 @@ export async function getLocalStorage() {
         networkActive: networkActive ?? Object.keys(network)[0],
         network,
         account,
-        pendingRequest: {}
+        request: {},
+        requestLog: {}
       }
     })
   }

--- a/storage/local/state.ts
+++ b/storage/local/state.ts
@@ -21,8 +21,8 @@ export type State = {
   paymaster: {
     [id: string]: Paymaster
   }
-  pendingRequest: Record<string, Request>
-  resolvedRequest: Record<string, RequestLog>
+  request: Record<string, Request>
+  requestLog: Record<string, RequestLog & { requestType: RequestType }>
 }
 
 /* Netowork */
@@ -105,7 +105,7 @@ export enum RequestType {
 }
 
 export type Request = TransactionRequest | Eip712Request
-export type RequestMeta<T> = {
+export type RequestMeta<T = {}> = {
   id: string
   createdAt: number
   accountId: string
@@ -132,7 +132,7 @@ export type Eip712Request = RequestMeta<
 /* Request Log */
 
 export type RequestLog = TransactionLog
-export type RequestLogMeta<T> = {
+export type RequestLogMeta<T = {}> = {
   id: string
   createdAt: number
   updatedAt: number
@@ -169,7 +169,7 @@ export type Erc4337TransactionLog =
   | Erc4337TransactionSucceeded
   | Erc4337TransactionReverted
 
-export type Erc4337TransactionLogMeta<T> = RequestLogMeta<
+export type Erc4337TransactionLogMeta<T = {}> = RequestLogMeta<
   | {
       type: TransactionType.Erc4337V0_6
       detail: {

--- a/storage/local/state.ts
+++ b/storage/local/state.ts
@@ -22,7 +22,7 @@ export type State = {
     [id: string]: Paymaster
   }
   request: Record<string, Request>
-  requestLog: Record<string, RequestLog & { requestType: RequestType }>
+  requestLog: Record<string, RequestLog>
 }
 
 /* Netowork */
@@ -125,22 +125,25 @@ export type TransactionRequest = RequestMeta<{
 export type Eip712Request = RequestMeta<
   {
     type: RequestType.Eip712
-    signature?: HexString
   } & Eip712TypedData
 >
 
 /* Request Log */
 
-export type RequestLog = TransactionLog
-export type RequestLogMeta<T = {}> = {
-  id: string
-  createdAt: number
-  updatedAt: number
-  accountId: string
-  networkId: string
-} & T
+export type RequestLog =
+  | ({
+      requestType: RequestType.Transaction
+    } & TransactionLog)
+  | ({
+      requestType: RequestType.Eip712
+    } & Eip712Log)
 
-/* Request Log - Transaction */
+export type RequestLogMeta<T = {}> = RequestMeta<{
+  updatedAt: number
+}> &
+  T
+
+/* Transaction Log */
 
 export type TransactionLog = Erc4337TransactionLog
 
@@ -226,3 +229,20 @@ export type Erc4337TransactionReverted = Erc4337TransactionLogMeta<{
     errorMessage: string
   }
 }>
+
+/* EIP-712 Log */
+
+export type Eip712Log = RequestLogMeta<
+  | {
+      status: Eip712Status.Resolved
+      signature: HexString
+    }
+  | {
+      status: Eip712Status.Rejected
+    }
+>
+
+export enum Eip712Status {
+  Resolved = "Resolved",
+  Rejected = "Rejected"
+}

--- a/storage/local/state.ts
+++ b/storage/local/state.ts
@@ -21,8 +21,8 @@ export type State = {
   paymaster: {
     [id: string]: Paymaster
   }
-  // TODO: Add `resolvedRequest`
   pendingRequest: Record<string, Request>
+  resolvedRequest: Record<string, RequestLog>
 }
 
 /* Netowork */
@@ -105,7 +105,6 @@ export enum RequestType {
 }
 
 export type Request = TransactionRequest | Eip712Request
-
 export type RequestMeta<T> = {
   id: string
   createdAt: number
@@ -130,7 +129,20 @@ export type Eip712Request = RequestMeta<
   } & Eip712TypedData
 >
 
-/* Transaction */
+/* Request Log */
+
+export type RequestLog = TransactionLog
+export type RequestLogMeta<T> = {
+  id: string
+  createdAt: number
+  updatedAt: number
+  accountId: string
+  networkId: string
+} & T
+
+/* Request Log - Transaction */
+
+export type TransactionLog = Erc4337TransactionLog
 
 export enum TransactionStatus {
   // User rejects the user operation.
@@ -146,33 +158,27 @@ export enum TransactionStatus {
 }
 
 export enum TransactionType {
-  ERC4337V0_6 = "ERC4337V0_6",
-  ERC4337V0_7 = "ERC4337V0_7"
+  Erc4337V0_6 = "Erc4337V0_6",
+  Erc4337V0_7 = "Erc4337V0_7"
 }
 
-/* Transaction - Log */
+export type Erc4337TransactionLog =
+  | Erc4337TransactionRejected
+  | Erc4337TransactionSent
+  | Erc4337TransactionFailed
+  | Erc4337TransactionSucceeded
+  | Erc4337TransactionReverted
 
-export type TransactionLog = ERC4337TransactionLog
-
-export type TransactionLogMeta<T> = {
-  id: string
-  accountId: string
-  networkId: string
-  createdAt: number
-} & T
-
-/* Transaction - ERC4337 */
-
-export type ERC4337TransactionMeta<T> = TransactionLogMeta<
+export type Erc4337TransactionLogMeta<T> = RequestLogMeta<
   | {
-      type: TransactionType.ERC4337V0_6
+      type: TransactionType.Erc4337V0_6
       detail: {
         entryPoint: HexString
         data: UserOperationDataV0_6
       }
     }
   | {
-      type: TransactionType.ERC4337V0_7
+      type: TransactionType.Erc4337V0_7
       detail: {
         entryPoint: HexString
         data: UserOperationDataV0_7
@@ -181,25 +187,18 @@ export type ERC4337TransactionMeta<T> = TransactionLogMeta<
 > &
   T
 
-export type ERC4337TransactionLog =
-  | ERC4337TransactionRejected
-  | ERC4337TransactionSent
-  | ERC4337TransactionFailed
-  | ERC4337TransactionSucceeded
-  | ERC4337TransactionReverted
-
-export type ERC4337TransactionRejected = ERC4337TransactionMeta<{
+export type Erc4337TransactionRejected = Erc4337TransactionLogMeta<{
   status: TransactionStatus.Rejected
 }>
 
-export type ERC4337TransactionSent = ERC4337TransactionMeta<{
+export type Erc4337TransactionSent = Erc4337TransactionLogMeta<{
   status: TransactionStatus.Sent
   receipt: {
     userOpHash: HexString
   }
 }>
 
-export type ERC4337TransactionFailed = ERC4337TransactionMeta<{
+export type Erc4337TransactionFailed = Erc4337TransactionLogMeta<{
   status: TransactionStatus.Failed
   receipt: {
     userOpHash: HexString
@@ -207,7 +206,7 @@ export type ERC4337TransactionFailed = ERC4337TransactionMeta<{
   }
 }>
 
-export type ERC4337TransactionSucceeded = ERC4337TransactionMeta<{
+export type Erc4337TransactionSucceeded = Erc4337TransactionLogMeta<{
   status: TransactionStatus.Succeeded
   receipt: {
     userOpHash: HexString
@@ -217,7 +216,7 @@ export type ERC4337TransactionSucceeded = ERC4337TransactionMeta<{
   }
 }>
 
-export type ERC4337TransactionReverted = ERC4337TransactionMeta<{
+export type Erc4337TransactionReverted = Erc4337TransactionLogMeta<{
   status: TransactionStatus.Reverted
   receipt: {
     userOpHash: HexString


### PR DESCRIPTION
> This PR is stacked on #203 

* Add `requestLog` to storage to temporarily store the result resolved from `request`. 
  * `RequestStoragePool` now only need to `wait` for `requestLog` update in order to get request result.
* Collect more logic into `StateActor`

The new request handling flow:

![Request handling flow](https://github.com/user-attachments/assets/ea769dbb-481c-480f-a5aa-8bbb7a90e716)
